### PR TITLE
fix(ci): add .npmrc legacy-peer-deps and bump Node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
npm ci was failing in CI because React 19 peer dependency conflicts require --legacy-peer-deps. Adding .npmrc makes this apply to all npm commands everywhere without manual flags.

Also bumps Node from 20 to 22 to silence the upcoming deprecation warning.