### PR TITLE
Link project to Expo account

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Medina",
-    "slug": "medina",
+    "slug": "medina-community",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -42,6 +42,13 @@
     ],
     "experiments": {
       "typedRoutes": true
-    }
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "727f2b4c-db63-4a55-b4d7-af4145da08f2"
+      }
+    },
+    "owner": "wisoumss-organization"
   }
 }


### PR DESCRIPTION
Adds EAS projectId, owner, and updates slug to match the Expo project created under wisoumss-organization.