### PR TITLE
ci: add branch-up-to-date check for PRs targeting dev

### DIFF
--- a/.github/workflows/branch-up-to-date.yml
+++ b/.github/workflows/branch-up-to-date.yml
@@ -1,0 +1,23 @@
+name: branch-up-to-date
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  check-up-to-date:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether PR branch contains latest dev
+        run: |
+          git fetch origin dev
+          BASE_SHA=$(git rev-parse origin/dev)
+          if git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+            echo "Branch is up to date with dev"
+          else
+            echo "Branch is out of date with dev"
+            exit 1
+          fi


### PR DESCRIPTION
Closes #37

## Summary
- Adds `.github/workflows/branch-up-to-date.yml`
- Runs on every PR targeting `dev`
- Fails if the PR branch does not contain the tip of `origin/dev`, preventing stale merges

## Test plan
- [ ] Open a PR from a branch that is behind `dev` → check fails
- [ ] Open a PR from a branch that is up to date → check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)