### PR TITLE
professional profile detail screen

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -1,24 +1,57 @@
-import { View, StyleSheet } from 'react-native';
+import { useCallback } from 'react';
+import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
 import { Screen } from '@components/layout';
-import { Text } from '@components/ui';
+import { Text, Button } from '@components/ui';
 import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
+import { useListProfessionals } from '@features/discover/hooks/useProfessional';
+import { ProfessionalCard } from '@features/discover/components/ProfessionalCard';
+
+function ListSeparator() {
+  return <View style={styles.separator} />;
+}
 
 export default function DiscoverScreen() {
+  const { data: professionals, isLoading, isError, refetch } = useListProfessionals();
+
+  const handleRetry = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
   return (
     <Screen>
       <View style={styles.header}>
         <Text variant="heading2">Discover</Text>
-        <Text variant="body" style={styles.subtitle}>
-          Explore people, places, and culture
+        <Text variant="bodySm" style={styles.subtitle}>
+          Find shops, services & classes near you
         </Text>
       </View>
 
-      <View style={styles.placeholder}>
-        <Text variant="body" style={styles.placeholderText}>
-          Discovery feed coming soon
-        </Text>
-      </View>
+      {isLoading && (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#cdc1ad" />
+        </View>
+      )}
+
+      {isError && (
+        <View style={styles.centered}>
+          <Text variant="bodySm" style={styles.errorText}>
+            Could not load professionals.
+          </Text>
+          <Button title="Try again" variant="outline" onPress={handleRetry} />
+        </View>
+      )}
+
+      {professionals !== undefined && (
+        <FlatList
+          data={professionals}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <ProfessionalCard professional={item} />}
+          contentContainerStyle={styles.list}
+          ItemSeparatorComponent={ListSeparator}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </Screen>
   );
 }
@@ -32,12 +65,20 @@ const styles = StyleSheet.create({
   subtitle: {
     color: colors.neutral[500],
   },
-  placeholder: {
+  centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    gap: spacing[4],
   },
-  placeholderText: {
-    color: colors.neutral[400],
+  errorText: {
+    color: colors.neutral[500],
+    textAlign: 'center',
+  },
+  list: {
+    paddingBottom: spacing[8],
+  },
+  separator: {
+    height: spacing[3],
   },
 });

--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -1,15 +1,11 @@
 import { useCallback } from 'react';
-import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Screen } from '@components/layout';
-import { Text, Button } from '@components/ui';
+import { Text } from '@components/ui';
 import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { useListProfessionals } from '@features/discover/hooks/useProfessional';
-import { ProfessionalCard } from '@features/discover/components/ProfessionalCard';
-
-function ListSeparator() {
-  return <View style={styles.separator} />;
-}
+import { ProfessionalList } from '@features/discover/components/ProfessionalList';
 
 export default function DiscoverScreen() {
   const { data: professionals, isLoading, isError, refetch } = useListProfessionals();
@@ -27,31 +23,13 @@ export default function DiscoverScreen() {
         </Text>
       </View>
 
-      {isLoading && (
-        <View style={styles.centered}>
-          <ActivityIndicator size="large" color="#cdc1ad" />
-        </View>
-      )}
-
-      {isError && (
-        <View style={styles.centered}>
-          <Text variant="bodySm" style={styles.errorText}>
-            Could not load professionals.
-          </Text>
-          <Button title="Try again" variant="outline" onPress={handleRetry} />
-        </View>
-      )}
-
-      {professionals !== undefined && (
-        <FlatList
-          data={professionals}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <ProfessionalCard professional={item} />}
-          contentContainerStyle={styles.list}
-          ItemSeparatorComponent={ListSeparator}
-          showsVerticalScrollIndicator={false}
-        />
-      )}
+      <ProfessionalList
+        data={professionals}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={handleRetry}
+        errorMessage="Could not load professionals."
+      />
     </Screen>
   );
 }
@@ -64,21 +42,5 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     color: colors.neutral[500],
-  },
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: spacing[4],
-  },
-  errorText: {
-    color: colors.neutral[500],
-    textAlign: 'center',
-  },
-  list: {
-    paddingBottom: spacing[8],
-  },
-  separator: {
-    height: spacing[3],
   },
 });

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,24 +1,69 @@
-import { View, StyleSheet } from 'react-native';
+import { useCallback } from 'react';
+import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
 import { Screen } from '@components/layout';
-import { Text } from '@components/ui';
+import { Text, Button } from '@components/ui';
 import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
+import { useListProfessionals } from '@features/discover/hooks/useProfessional';
+import { ProfessionalCard } from '@features/discover/components/ProfessionalCard';
+import { useFavoritesStore } from '@store/favorites.store';
+
+function ListSeparator() {
+  return <View style={styles.separator} />;
+}
 
 export default function FavoritesScreen() {
+  const { data: professionals, isLoading, isError, refetch } = useListProfessionals();
+  const favoritedIds = useFavoritesStore((s) => s.favoritedIds);
+
+  const handleRetry = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
+  const favorited = professionals?.filter((p) => favoritedIds.includes(p.id)) ?? [];
+
   return (
     <Screen>
       <View style={styles.header}>
         <Text variant="heading2">Favorites</Text>
-        <Text variant="body" style={styles.subtitle}>
-          Events and places you've saved
+        <Text variant="bodySm" style={styles.subtitle}>
+          Shops and services you&apos;ve saved
         </Text>
       </View>
 
-      <View style={styles.placeholder}>
-        <Text variant="body" style={styles.placeholderText}>
-          Saved items coming soon
-        </Text>
-      </View>
+      {isLoading && (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#cdc1ad" />
+        </View>
+      )}
+
+      {isError && (
+        <View style={styles.centered}>
+          <Text variant="bodySm" style={styles.errorText}>
+            Could not load favorites.
+          </Text>
+          <Button title="Try again" variant="outline" onPress={handleRetry} />
+        </View>
+      )}
+
+      {!isLoading && !isError && favorited.length === 0 && (
+        <View style={styles.centered}>
+          <Text variant="bodySm" style={styles.emptyText}>
+            Tap the heart on any profile to save it here.
+          </Text>
+        </View>
+      )}
+
+      {favorited.length > 0 && (
+        <FlatList
+          data={favorited}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <ProfessionalCard professional={item} />}
+          contentContainerStyle={styles.list}
+          ItemSeparatorComponent={ListSeparator}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </Screen>
   );
 }
@@ -32,12 +77,25 @@ const styles = StyleSheet.create({
   subtitle: {
     color: colors.neutral[500],
   },
-  placeholder: {
+  centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    gap: spacing[4],
   },
-  placeholderText: {
+  errorText: {
+    color: colors.neutral[500],
+    textAlign: 'center',
+  },
+  emptyText: {
     color: colors.neutral[400],
+    textAlign: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  list: {
+    paddingBottom: spacing[8],
+  },
+  separator: {
+    height: spacing[3],
   },
 });

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,16 +1,12 @@
 import { useCallback } from 'react';
-import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Screen } from '@components/layout';
-import { Text, Button } from '@components/ui';
+import { Text } from '@components/ui';
 import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { useListProfessionals } from '@features/discover/hooks/useProfessional';
-import { ProfessionalCard } from '@features/discover/components/ProfessionalCard';
+import { ProfessionalList } from '@features/discover/components/ProfessionalList';
 import { useFavoritesStore } from '@store/favorites.store';
-
-function ListSeparator() {
-  return <View style={styles.separator} />;
-}
 
 export default function FavoritesScreen() {
   const { data: professionals, isLoading, isError, refetch } = useListProfessionals();
@@ -31,39 +27,14 @@ export default function FavoritesScreen() {
         </Text>
       </View>
 
-      {isLoading && (
-        <View style={styles.centered}>
-          <ActivityIndicator size="large" color="#cdc1ad" />
-        </View>
-      )}
-
-      {isError && (
-        <View style={styles.centered}>
-          <Text variant="bodySm" style={styles.errorText}>
-            Could not load favorites.
-          </Text>
-          <Button title="Try again" variant="outline" onPress={handleRetry} />
-        </View>
-      )}
-
-      {!isLoading && !isError && favorited.length === 0 && (
-        <View style={styles.centered}>
-          <Text variant="bodySm" style={styles.emptyText}>
-            Tap the heart on any profile to save it here.
-          </Text>
-        </View>
-      )}
-
-      {favorited.length > 0 && (
-        <FlatList
-          data={favorited}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <ProfessionalCard professional={item} />}
-          contentContainerStyle={styles.list}
-          ItemSeparatorComponent={ListSeparator}
-          showsVerticalScrollIndicator={false}
-        />
-      )}
+      <ProfessionalList
+        data={favorited}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={handleRetry}
+        errorMessage="Could not load favorites."
+        emptyMessage="Tap the heart on any profile to save it here."
+      />
     </Screen>
   );
 }
@@ -76,26 +47,5 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     color: colors.neutral[500],
-  },
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: spacing[4],
-  },
-  errorText: {
-    color: colors.neutral[500],
-    textAlign: 'center',
-  },
-  emptyText: {
-    color: colors.neutral[400],
-    textAlign: 'center',
-    paddingHorizontal: spacing[8],
-  },
-  list: {
-    paddingBottom: spacing[8],
-  },
-  separator: {
-    height: spacing[3],
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,6 +38,7 @@ export default function RootLayout() {
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="(tabs)" />
           <Stack.Screen name="(auth)" />
+          <Stack.Screen name="professional/[id]" />
           <Stack.Screen name="+not-found" />
         </Stack>
       </QueryClientProvider>

--- a/app/professional/[id].tsx
+++ b/app/professional/[id].tsx
@@ -71,11 +71,15 @@ export default function ProfessionalProfileScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { data: professional, isLoading, isError, refetch } = useGetProfessional(id);
-  const { isFavorited, toggle, isToggling } = useFavorite(professional?.isFavorited ?? false);
+  const { isFavorited, toggle } = useFavorite(id);
 
   const handleBack = useCallback(() => {
     router.back();
   }, [router]);
+
+  const handleRetry = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   // ── Loading ────────────────────────────────────────────────────────────────
 
@@ -120,7 +124,7 @@ export default function ProfessionalProfileScreen() {
           <Button
             title="Try again"
             variant="outline"
-            onPress={() => void refetch()}
+            onPress={handleRetry}
             style={styles.retryBtn}
           />
         </View>
@@ -145,9 +149,8 @@ export default function ProfessionalProfileScreen() {
           <Ionicons name="arrow-back" size={22} color="#cdc1ad" />
         </TouchableOpacity>
         <TouchableOpacity
-          onPress={() => void toggle()}
+          onPress={toggle}
           style={styles.headerBtn}
-          disabled={isToggling}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
           <Ionicons
@@ -177,9 +180,9 @@ export default function ProfessionalProfileScreen() {
               <View style={[styles.badge, styles.badgePrice]}>
                 <Text style={styles.badgeText}>
                   {professional.priceRange}
-                  {professional.startingPrice !== undefined
-                    ? ` · from ${professional.startingPrice}`
-                    : ''}
+                  {professional.startingPrice === undefined
+                    ? ''
+                    : ` · from ${professional.startingPrice}`}
                 </Text>
               </View>
             )}
@@ -270,20 +273,28 @@ export default function ProfessionalProfileScreen() {
                 onPress={() => void openLink(`tel:${professional.phone}`)}
               />
             )}
-            {professional.bookingLink !== undefined && (
-              <ContactRow
-                icon="calendar-outline"
-                label="Book an appointment"
-                onPress={() => void openLink(professional.bookingLink!)}
-              />
-            )}
-            {professional.website !== undefined && (
-              <ContactRow
-                icon="link-outline"
-                label={professional.website}
-                onPress={() => void openLink(professional.website!)}
-              />
-            )}
+            {professional.bookingLink !== undefined &&
+              (() => {
+                const link = professional.bookingLink;
+                return (
+                  <ContactRow
+                    icon="calendar-outline"
+                    label="Book an appointment"
+                    onPress={() => void openLink(link)}
+                  />
+                );
+              })()}
+            {professional.website !== undefined &&
+              (() => {
+                const site = professional.website;
+                return (
+                  <ContactRow
+                    icon="link-outline"
+                    label={site}
+                    onPress={() => void openLink(site)}
+                  />
+                );
+              })()}
           </View>
         </View>
       </ScrollView>

--- a/app/professional/[id].tsx
+++ b/app/professional/[id].tsx
@@ -1,0 +1,480 @@
+import { useCallback } from 'react';
+import {
+  View,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Linking,
+  StyleSheet,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { Text, Button } from '@components/ui';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+import { fontSize } from '@theme/typography';
+import { PROFILE_TYPE_LABELS, SERVICE_TYPE_LABELS } from '@app-types/professional';
+import { useGetProfessional } from '@features/discover/hooks/useProfessional';
+import { useFavorite } from '@features/favorites/hooks/useFavorite';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+async function openLink(url: string): Promise<void> {
+  const supported = await Linking.canOpenURL(url);
+  if (supported) {
+    await Linking.openURL(url);
+  }
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function ContactRow({
+  icon,
+  label,
+  onPress,
+}: Readonly<{
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+  onPress: () => void;
+}>) {
+  return (
+    <TouchableOpacity onPress={onPress} activeOpacity={0.7} style={styles.contactRow}>
+      <View style={styles.contactIconWrap}>
+        <Ionicons name={icon} size={16} color="#cdc1ad" />
+      </View>
+      <Text style={styles.contactLabel}>{label}</Text>
+      <Ionicons name="chevron-forward" size={14} color={colors.burgundy.muted} />
+    </TouchableOpacity>
+  );
+}
+
+function InfoChip({ label }: Readonly<{ label: string }>) {
+  return (
+    <View style={styles.chip}>
+      <Text style={styles.chipText}>{label}</Text>
+    </View>
+  );
+}
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+
+export default function ProfessionalProfileScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { data: professional, isLoading, isError, refetch } = useGetProfessional(id);
+  const { isFavorited, toggle, isToggling } = useFavorite(professional?.isFavorited ?? false);
+
+  const handleBack = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  // ── Loading ────────────────────────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <View style={styles.headerBar}>
+          <TouchableOpacity
+            onPress={handleBack}
+            style={styles.headerBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="arrow-back" size={22} color="#cdc1ad" />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#cdc1ad" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // ── Error ──────────────────────────────────────────────────────────────────
+
+  if (isError || professional === undefined) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <View style={styles.headerBar}>
+          <TouchableOpacity
+            onPress={handleBack}
+            style={styles.headerBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="arrow-back" size={22} color="#cdc1ad" />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.centered}>
+          <Ionicons name="alert-circle-outline" size={48} color={colors.burgundy.muted} />
+          <Text variant="bodySm" style={styles.errorText}>
+            Could not load this profile.
+          </Text>
+          <Button
+            title="Try again"
+            variant="outline"
+            onPress={() => void refetch()}
+            style={styles.retryBtn}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // ── Derived display values ─────────────────────────────────────────────────
+
+  const profileTypeLabel = PROFILE_TYPE_LABELS[professional.profileType];
+  const serviceTypeLabels = professional.serviceTypes.map((v) => SERVICE_TYPE_LABELS[v]);
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      {/* Header */}
+      <View style={styles.headerBar}>
+        <TouchableOpacity
+          onPress={handleBack}
+          style={styles.headerBtn}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="arrow-back" size={22} color="#cdc1ad" />
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => void toggle()}
+          style={styles.headerBtn}
+          disabled={isToggling}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons
+            name={isFavorited ? 'heart' : 'heart-outline'}
+            size={22}
+            color={isFavorited ? colors.crimson[400] : '#cdc1ad'}
+          />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll} showsVerticalScrollIndicator={false}>
+        {/* Hero */}
+        <View style={styles.hero}>
+          <View style={styles.avatarCircle}>
+            <Text style={styles.avatarInitials}>
+              {getInitials(professional.businessName) || '?'}
+            </Text>
+          </View>
+          <Text variant="heading2" style={styles.businessName}>
+            {professional.businessName}
+          </Text>
+          <View style={styles.badgeRow}>
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{profileTypeLabel}</Text>
+            </View>
+            {professional.priceRange !== undefined && (
+              <View style={[styles.badge, styles.badgePrice]}>
+                <Text style={styles.badgeText}>
+                  {professional.priceRange}
+                  {professional.startingPrice !== undefined
+                    ? ` · from ${professional.startingPrice}`
+                    : ''}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        <View style={styles.divider} />
+
+        {/* Category & subcategories */}
+        <View style={styles.section}>
+          <Text variant="overline" style={styles.sectionLabel}>
+            Speciality
+          </Text>
+          <View style={styles.chipRow}>
+            <View style={[styles.chip, styles.chipAccent]}>
+              <Text style={[styles.chipText, styles.chipTextAccent]}>{professional.category}</Text>
+            </View>
+            {professional.subcategories.map((sub) => (
+              <InfoChip key={sub} label={sub} />
+            ))}
+          </View>
+        </View>
+
+        {/* Service types */}
+        {serviceTypeLabels.length > 0 && (
+          <View style={styles.section}>
+            <Text variant="overline" style={styles.sectionLabel}>
+              How they work
+            </Text>
+            <View style={styles.chipRow}>
+              {serviceTypeLabels.map((label) => (
+                <InfoChip key={label} label={label} />
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* Location */}
+        <View style={styles.section}>
+          <Text variant="overline" style={styles.sectionLabel}>
+            Location
+          </Text>
+          <View style={styles.locationRow}>
+            <Ionicons name="location-outline" size={14} color={colors.burgundy.muted} />
+            <Text variant="bodySm" style={styles.locationText}>
+              Based in {professional.basedIn}
+            </Text>
+          </View>
+          {professional.servesAreas.length > 0 && (
+            <Text variant="caption" style={styles.servesText}>
+              Serves: {professional.servesAreas.join(', ')}
+            </Text>
+          )}
+        </View>
+
+        {/* About */}
+        <View style={styles.section}>
+          <Text variant="overline" style={styles.sectionLabel}>
+            About
+          </Text>
+          <Text variant="bodySm" style={styles.description}>
+            {professional.description}
+          </Text>
+        </View>
+
+        {/* Contact */}
+        <View style={styles.section}>
+          <Text variant="overline" style={styles.sectionLabel}>
+            Contact
+          </Text>
+          <View style={styles.contactList}>
+            <ContactRow
+              icon="mail-outline"
+              label={professional.inquiryEmail}
+              onPress={() => void openLink(`mailto:${professional.inquiryEmail}`)}
+            />
+            {professional.instagram !== undefined && (
+              <ContactRow
+                icon="logo-instagram"
+                label={`@${professional.instagram}`}
+                onPress={() => void openLink(`https://instagram.com/${professional.instagram}`)}
+              />
+            )}
+            {professional.phone !== undefined && (
+              <ContactRow
+                icon="call-outline"
+                label={professional.phone}
+                onPress={() => void openLink(`tel:${professional.phone}`)}
+              />
+            )}
+            {professional.bookingLink !== undefined && (
+              <ContactRow
+                icon="calendar-outline"
+                label="Book an appointment"
+                onPress={() => void openLink(professional.bookingLink!)}
+              />
+            )}
+            {professional.website !== undefined && (
+              <ContactRow
+                icon="link-outline"
+                label={professional.website}
+                onPress={() => void openLink(professional.website!)}
+              />
+            )}
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.burgundy.deep,
+  },
+
+  // Header
+  headerBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing[6],
+    paddingVertical: spacing[3],
+  },
+  headerBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.burgundy.raised,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  // Loading / error
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing[4],
+  },
+  errorText: {
+    color: colors.burgundy.muted,
+    textAlign: 'center',
+  },
+  retryBtn: {
+    minWidth: 140,
+  },
+
+  // Scroll
+  scroll: {
+    paddingHorizontal: spacing[6],
+    paddingBottom: spacing[12],
+  },
+
+  // Hero
+  hero: {
+    alignItems: 'center',
+    paddingVertical: spacing[8],
+    gap: spacing[3],
+  },
+  avatarCircle: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    backgroundColor: colors.burgundy.raised,
+    borderWidth: 2,
+    borderColor: colors.burgundy.mid,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing[2],
+  },
+  avatarInitials: {
+    fontSize: fontSize.xl,
+    fontWeight: '700',
+    color: '#cdc1ad',
+    letterSpacing: 1,
+  },
+  businessName: {
+    color: '#cdc1ad',
+    textAlign: 'center',
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    justifyContent: 'center',
+  },
+  badge: {
+    paddingVertical: spacing[1],
+    paddingHorizontal: spacing[3],
+    borderRadius: 20,
+    backgroundColor: colors.burgundy.raised,
+    borderWidth: 1,
+    borderColor: colors.burgundy.mid,
+  },
+  badgePrice: {
+    borderColor: '#cdc1ad',
+  },
+  badgeText: {
+    fontSize: fontSize.xs,
+    color: '#cdc1ad',
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+
+  // Divider
+  divider: {
+    height: 1,
+    backgroundColor: colors.burgundy.surface,
+    marginBottom: spacing[6],
+  },
+
+  // Sections
+  section: {
+    marginBottom: spacing[8],
+    gap: spacing[3],
+  },
+  sectionLabel: {
+    color: '#7b625b',
+  },
+
+  // Chips
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  chip: {
+    paddingVertical: spacing[1],
+    paddingHorizontal: spacing[3],
+    borderRadius: 20,
+    backgroundColor: colors.burgundy.raised,
+    borderWidth: 1,
+    borderColor: colors.burgundy.mid,
+  },
+  chipAccent: {
+    borderColor: '#cdc1ad',
+  },
+  chipText: {
+    fontSize: fontSize.xs,
+    color: '#cdc1ad',
+    fontWeight: '500',
+  },
+  chipTextAccent: {
+    fontWeight: '700',
+  },
+
+  // Location
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  locationText: {
+    color: '#cdc1ad',
+  },
+  servesText: {
+    color: colors.burgundy.muted,
+    marginTop: spacing[1],
+  },
+
+  // Description
+  description: {
+    color: colors.beige[300],
+    lineHeight: 22,
+  },
+
+  // Contact
+  contactList: {
+    gap: spacing[1],
+  },
+  contactRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.burgundy.surface,
+    borderRadius: 10,
+  },
+  contactIconWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.burgundy.raised,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  contactLabel: {
+    flex: 1,
+    fontSize: fontSize.sm,
+    color: '#cdc1ad',
+    fontWeight: '500',
+  },
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,15 +30,10 @@ module.exports = {
     '!src/**/*.spec.{ts,tsx}',
     // Barrel/index files: just re-exports, no logic to test
     '!src/**/index.ts',
-    // Infrastructure: HTTP clients and Zustand stores depend on native modules
-    // and network — covered by integration tests, not unit tests.
+    // Infrastructure: HTTP clients depend on the network — covered by integration tests.
     '!src/services/**',
-    '!src/store/**',
-    // Pure TypeScript type definitions — no runtime logic to test.
-    '!src/types/**',
     // Design tokens: pure constant objects, no logic to test.
     '!src/theme/**',
-    '!src/features/**/hooks/**',
   ],
 
   coverageThreshold: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -7,3 +7,12 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 /* eslint-enable @typescript-eslint/no-require-imports */
+
+// @expo/vector-icons depends on expo-asset (a native module unavailable in Node).
+// Return a no-op component for every icon family so any test can import icons freely.
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+  MaterialIcons: () => null,
+  FontAwesome: () => null,
+  Feather: () => null,
+}));

--- a/src/features/discover/components/ProfessionalCard.tsx
+++ b/src/features/discover/components/ProfessionalCard.tsx
@@ -1,0 +1,141 @@
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { Text } from '@components/ui';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+import { fontSize } from '@theme/typography';
+import { PROFILE_TYPE_LABELS } from '@app-types/professional';
+import type { Professional } from '@app-types/professional';
+
+interface ProfessionalCardProps {
+  professional: Professional;
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+export function ProfessionalCard({ professional }: Readonly<ProfessionalCardProps>) {
+  const router = useRouter();
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/professional/${professional.id}`)}
+      activeOpacity={0.85}
+      style={styles.card}
+    >
+      {/* Avatar */}
+      <View style={styles.avatar}>
+        <Text style={styles.avatarInitials}>{getInitials(professional.businessName) || '?'}</Text>
+      </View>
+
+      {/* Info */}
+      <View style={styles.info}>
+        <Text style={styles.name} numberOfLines={1}>
+          {professional.businessName}
+        </Text>
+        <Text style={styles.category} numberOfLines={1}>
+          {professional.category}
+          {professional.subcategories.length > 0
+            ? ` · ${professional.subcategories.slice(0, 2).join(', ')}`
+            : ''}
+        </Text>
+        <View style={styles.meta}>
+          <Ionicons name="location-outline" size={11} color={colors.burgundy.muted} />
+          <Text style={styles.metaText}>{professional.basedIn}</Text>
+          {professional.priceRange !== undefined && (
+            <>
+              <Text style={styles.metaDot}>·</Text>
+              <Text style={styles.metaText}>{professional.priceRange}</Text>
+            </>
+          )}
+        </View>
+      </View>
+
+      {/* Type badge */}
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>{PROFILE_TYPE_LABELS[professional.profileType]}</Text>
+      </View>
+
+      <Ionicons name="chevron-forward" size={16} color={colors.burgundy.muted} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingVertical: spacing[4],
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.burgundy.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.burgundy.raised,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: colors.burgundy.raised,
+    borderWidth: 1,
+    borderColor: colors.burgundy.mid,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+  avatarInitials: {
+    fontSize: fontSize.sm,
+    fontWeight: '700',
+    color: '#cdc1ad',
+    letterSpacing: 0.5,
+  },
+  info: {
+    flex: 1,
+    gap: spacing[0.5],
+  },
+  name: {
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    color: '#cdc1ad',
+  },
+  category: {
+    fontSize: fontSize.xs,
+    color: colors.burgundy.muted,
+  },
+  meta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    marginTop: spacing[0.5],
+  },
+  metaText: {
+    fontSize: fontSize.xs,
+    color: colors.burgundy.muted,
+  },
+  metaDot: {
+    fontSize: fontSize.xs,
+    color: colors.burgundy.mid,
+  },
+  badge: {
+    paddingVertical: 3,
+    paddingHorizontal: spacing[2],
+    borderRadius: 20,
+    backgroundColor: colors.burgundy.raised,
+    borderWidth: 1,
+    borderColor: colors.burgundy.mid,
+    flexShrink: 0,
+  },
+  badgeText: {
+    fontSize: 10,
+    color: '#cdc1ad',
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+});

--- a/src/features/discover/components/ProfessionalList.tsx
+++ b/src/features/discover/components/ProfessionalList.tsx
@@ -1,0 +1,96 @@
+import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { Text, Button } from '@components/ui';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+import { ProfessionalCard } from './ProfessionalCard';
+import type { Professional } from '@app-types/professional';
+
+interface ProfessionalListProps {
+  data: Professional[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => Promise<void>;
+  errorMessage: string;
+  emptyMessage?: string | undefined;
+}
+
+function ListSeparator() {
+  return <View style={styles.separator} />;
+}
+
+export function ProfessionalList({
+  data,
+  isLoading,
+  isError,
+  onRetry,
+  errorMessage,
+  emptyMessage,
+}: Readonly<ProfessionalListProps>) {
+  if (isLoading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#cdc1ad" />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.centered}>
+        <Text variant="bodySm" style={styles.errorText}>
+          {errorMessage}
+        </Text>
+        <Button title="Try again" variant="outline" onPress={onRetry} />
+      </View>
+    );
+  }
+
+  if (emptyMessage !== undefined && (data === undefined || data.length === 0)) {
+    return (
+      <View style={styles.centered}>
+        <Text variant="bodySm" style={styles.emptyText}>
+          {emptyMessage}
+        </Text>
+      </View>
+    );
+  }
+
+  if (data === undefined || data.length === 0) {
+    return null;
+  }
+
+  return (
+    <FlatList
+      data={data}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => <ProfessionalCard professional={item} />}
+      contentContainerStyle={styles.list}
+      ItemSeparatorComponent={ListSeparator}
+      showsVerticalScrollIndicator={false}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing[4],
+  },
+  errorText: {
+    color: colors.neutral[500],
+    textAlign: 'center',
+  },
+  emptyText: {
+    color: colors.neutral[400],
+    textAlign: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  list: {
+    paddingBottom: spacing[8],
+  },
+  separator: {
+    height: spacing[3],
+  },
+});

--- a/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
+++ b/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from '@testing-library/react-native';
+import { ProfessionalCard } from '../ProfessionalCard';
+import type { Professional } from '@app-types/professional';
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }));
+
+const base: Professional = {
+  id: '1',
+  businessName: 'Henna by Fatima',
+  profileType: 'service',
+  category: 'Beauty',
+  subcategories: ['Henna', 'Makeup'],
+  serviceTypes: ['at_home'],
+  basedIn: 'Montreal',
+  servesAreas: ['Montreal'],
+  description: 'Test description',
+  inquiryEmail: 'test@test.com',
+  priceRange: '$$',
+  status: 'approved',
+  isFavorited: false,
+};
+
+describe('ProfessionalCard', () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it('renders business name, category, location and type badge', () => {
+    const { getByText } = render(<ProfessionalCard professional={base} />);
+    expect(getByText('Henna by Fatima')).toBeTruthy();
+    expect(getByText('Beauty · Henna, Makeup')).toBeTruthy();
+    expect(getByText('Montreal')).toBeTruthy();
+    expect(getByText('Service')).toBeTruthy();
+  });
+
+  it('renders avatar initials from the first two words', () => {
+    const { getByText } = render(<ProfessionalCard professional={base} />);
+    expect(getByText('HB')).toBeTruthy(); // "Henna by Fatima" → H + B
+  });
+
+  it('shows "?" when business name is empty', () => {
+    const { getByText } = render(
+      <ProfessionalCard professional={{ ...base, businessName: '' }} />,
+    );
+    expect(getByText('?')).toBeTruthy();
+  });
+
+  it('shows price range when provided', () => {
+    const { getByText } = render(<ProfessionalCard professional={base} />);
+    expect(getByText('$$')).toBeTruthy();
+  });
+
+  it('hides price range when undefined', () => {
+    const { queryByText } = render(
+      <ProfessionalCard professional={{ ...base, priceRange: undefined }} />,
+    );
+    expect(queryByText('$$')).toBeNull();
+  });
+
+  it('shows only category when there are no subcategories', () => {
+    const { getByText } = render(
+      <ProfessionalCard professional={{ ...base, subcategories: [] }} />,
+    );
+    expect(getByText('Beauty')).toBeTruthy();
+  });
+
+  it('navigates to the profile screen on press', () => {
+    const { getByText } = render(<ProfessionalCard professional={base} />);
+    fireEvent.press(getByText('Henna by Fatima'));
+    expect(mockPush).toHaveBeenCalledWith('/professional/1');
+  });
+});

--- a/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
+++ b/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
@@ -38,9 +38,7 @@ describe('ProfessionalCard', () => {
   });
 
   it('shows "?" when business name is empty', () => {
-    const { getByText } = render(
-      <ProfessionalCard professional={{ ...base, businessName: '' }} />,
-    );
+    const { getByText } = render(<ProfessionalCard professional={{ ...base, businessName: '' }} />);
     expect(getByText('?')).toBeTruthy();
   });
 

--- a/src/features/discover/components/__tests__/ProfessionalList.test.tsx
+++ b/src/features/discover/components/__tests__/ProfessionalList.test.tsx
@@ -1,0 +1,106 @@
+import { render, fireEvent } from '@testing-library/react-native';
+import { ActivityIndicator } from 'react-native';
+import { ProfessionalList } from '../ProfessionalList';
+import type { Professional } from '@app-types/professional';
+
+const mockRetry = jest.fn().mockResolvedValue(undefined);
+
+const professional: Professional = {
+  id: '1',
+  businessName: 'Henna by Fatima',
+  profileType: 'service',
+  category: 'Beauty',
+  subcategories: [],
+  serviceTypes: [],
+  basedIn: 'Montreal',
+  servesAreas: [],
+  description: 'Test',
+  inquiryEmail: 'test@test.com',
+  status: 'approved',
+  isFavorited: false,
+};
+
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+describe('ProfessionalList', () => {
+  it('shows a spinner while loading', () => {
+    const { UNSAFE_getByType } = render(
+      <ProfessionalList
+        data={undefined}
+        isLoading={true}
+        isError={false}
+        onRetry={mockRetry}
+        errorMessage="Error"
+      />,
+    );
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  });
+
+  it('shows the error message and retry button on error', () => {
+    const { getByText } = render(
+      <ProfessionalList
+        data={undefined}
+        isLoading={false}
+        isError={true}
+        onRetry={mockRetry}
+        errorMessage="Could not load."
+      />,
+    );
+    expect(getByText('Could not load.')).toBeTruthy();
+    expect(getByText('Try again')).toBeTruthy();
+  });
+
+  it('calls onRetry when the retry button is pressed', () => {
+    const { getByText } = render(
+      <ProfessionalList
+        data={undefined}
+        isLoading={false}
+        isError={true}
+        onRetry={mockRetry}
+        errorMessage="Error"
+      />,
+    );
+    fireEvent.press(getByText('Try again'));
+    expect(mockRetry).toHaveBeenCalled();
+  });
+
+  it('shows the empty message when data is empty and emptyMessage is provided', () => {
+    const { getByText } = render(
+      <ProfessionalList
+        data={[]}
+        isLoading={false}
+        isError={false}
+        onRetry={mockRetry}
+        errorMessage="Error"
+        emptyMessage="Nothing saved yet."
+      />,
+    );
+    expect(getByText('Nothing saved yet.')).toBeTruthy();
+  });
+
+  it('renders null when data is empty and no emptyMessage is provided', () => {
+    const { toJSON } = render(
+      <ProfessionalList
+        data={[]}
+        isLoading={false}
+        isError={false}
+        onRetry={mockRetry}
+        errorMessage="Error"
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the list of professionals', () => {
+    const { getByText } = render(
+      <ProfessionalList
+        data={[professional]}
+        isLoading={false}
+        isError={false}
+        onRetry={mockRetry}
+        errorMessage="Error"
+      />,
+    );
+    expect(getByText('Henna by Fatima')).toBeTruthy();
+  });
+});

--- a/src/features/discover/hooks/__tests__/useProfessional.test.ts
+++ b/src/features/discover/hooks/__tests__/useProfessional.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useListProfessionals, useGetProfessional } from '../useProfessional';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useListProfessionals', () => {
+  it('returns all professionals', async () => {
+    const { result } = renderHook(() => useListProfessionals(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(3);
+  });
+});
+
+describe('useGetProfessional', () => {
+  it('returns the matching professional by id', async () => {
+    const { result } = renderHook(() => useGetProfessional('1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.businessName).toBe('Henna by Fatima');
+  });
+
+  it('throws an error for an unknown id', async () => {
+    const { result } = renderHook(() => useGetProfessional('999'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error('Professional not found'));
+  });
+});

--- a/src/features/discover/hooks/useProfessional.ts
+++ b/src/features/discover/hooks/useProfessional.ts
@@ -64,13 +64,22 @@ const MOCK_PROFESSIONALS: Record<string, Professional> = {
   },
 };
 
-// ── Hook ──────────────────────────────────────────────────────────────────────
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+export function useListProfessionals() {
+  return useQuery({
+    queryKey: ['professionals'],
+    queryFn: async (): Promise<Professional[]> => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      return Object.values(MOCK_PROFESSIONALS);
+    },
+  });
+}
 
 export function useGetProfessional(id: string) {
   return useQuery({
     queryKey: ['professionals', id],
     queryFn: async (): Promise<Professional> => {
-      // Simulate network latency
       await new Promise((resolve) => setTimeout(resolve, 600));
       const professional = MOCK_PROFESSIONALS[id];
       if (professional === undefined) {

--- a/src/features/discover/hooks/useProfessional.ts
+++ b/src/features/discover/hooks/useProfessional.ts
@@ -1,0 +1,82 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Professional } from '@app-types/professional';
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+// Replace queryFn body with: const { data } = await apiClient.get<Professional>(`/professionals/${id}`); return data;
+
+const MOCK_PROFESSIONALS: Record<string, Professional> = {
+  '1': {
+    id: '1',
+    businessName: 'Henna by Fatima',
+    profileType: 'service',
+    category: 'Beauty',
+    subcategories: ['Henna', 'Makeup'],
+    serviceTypes: ['at_home', 'travels_to_client'],
+    basedIn: 'Montreal',
+    servesAreas: ['Montreal', 'Laval', 'Longueuil'],
+    description:
+      'Specialised henna artist and makeup artist serving the Montreal Muslim community. Available for weddings, Eid events, and special occasions. Traditional and modern designs tailored just for you.',
+    inquiryEmail: 'hello@hennabyfattima.com',
+    instagram: 'hennabyfattima',
+    phone: '+1 514 000 0000',
+    bookingLink: 'https://calendly.com/henna',
+    priceRange: '$$',
+    startingPrice: '$50',
+    status: 'approved',
+    isFavorited: false,
+  },
+  '2': {
+    id: '2',
+    businessName: 'Nour Pilates',
+    profileType: 'service',
+    category: 'Fitness',
+    subcategories: ['Pilates / Yoga', 'Women Fitness Classes'],
+    serviceTypes: ['has_studio', 'online'],
+    basedIn: 'Laval',
+    servesAreas: ['Laval', 'Montreal', 'Online'],
+    description:
+      'Women-only pilates and wellness studio in Laval. Online classes available. All levels welcome — from beginners to advanced practitioners.',
+    inquiryEmail: 'nour@nourpilates.ca',
+    instagram: 'nourpilates',
+    website: 'https://nourpilates.ca',
+    priceRange: '$$$',
+    startingPrice: '$25/session',
+    status: 'approved',
+    isFavorited: true,
+  },
+  '3': {
+    id: '3',
+    businessName: 'Sakina Sweets',
+    profileType: 'shop',
+    category: 'Food & Sweets',
+    subcategories: [],
+    serviceTypes: [],
+    basedIn: 'Brossard',
+    servesAreas: ['Brossard', 'Longueuil', "At client's home"],
+    description:
+      'Handmade Middle Eastern sweets and custom celebration cakes. Perfect for weddings, Eid, and all your special moments. Orders placed 1 week in advance.',
+    inquiryEmail: 'orders@skinasweets.com',
+    instagram: 'sakinasweets',
+    phone: '+1 438 000 0000',
+    priceRange: '$',
+    status: 'approved',
+    isFavorited: false,
+  },
+};
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useGetProfessional(id: string) {
+  return useQuery({
+    queryKey: ['professionals', id],
+    queryFn: async (): Promise<Professional> => {
+      // Simulate network latency
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      const professional = MOCK_PROFESSIONALS[id];
+      if (professional === undefined) {
+        throw new Error('Professional not found');
+      }
+      return professional;
+    },
+  });
+}

--- a/src/features/favorites/hooks/__tests__/useFavorite.test.ts
+++ b/src/features/favorites/hooks/__tests__/useFavorite.test.ts
@@ -1,6 +1,23 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 import { useFavorite } from '../useFavorite';
 import { useFavoritesStore } from '@store/favorites.store';
+
+jest.mock('@services/api.client', () => ({
+  apiClient: {
+    post: jest.fn().mockResolvedValue({}),
+    delete: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
 
 beforeEach(() => {
   useFavoritesStore.setState({ favoritedIds: [] });
@@ -8,18 +25,18 @@ beforeEach(() => {
 
 describe('useFavorite', () => {
   it('returns false when the professional is not favorited', () => {
-    const { result } = renderHook(() => useFavorite('1'));
+    const { result } = renderHook(() => useFavorite('1'), { wrapper: createWrapper() });
     expect(result.current.isFavorited).toBe(false);
   });
 
-  it('returns true after toggling on', () => {
-    const { result } = renderHook(() => useFavorite('1'));
+  it('optimistically flips to true on toggle', () => {
+    const { result } = renderHook(() => useFavorite('1'), { wrapper: createWrapper() });
     act(() => result.current.toggle());
     expect(result.current.isFavorited).toBe(true);
   });
 
-  it('returns false after toggling off', () => {
-    const { result } = renderHook(() => useFavorite('1'));
+  it('optimistically flips back to false on second toggle', () => {
+    const { result } = renderHook(() => useFavorite('1'), { wrapper: createWrapper() });
     act(() => result.current.toggle());
     act(() => result.current.toggle());
     expect(result.current.isFavorited).toBe(false);

--- a/src/features/favorites/hooks/__tests__/useFavorite.test.ts
+++ b/src/features/favorites/hooks/__tests__/useFavorite.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useFavorite } from '../useFavorite';
+import { useFavoritesStore } from '@store/favorites.store';
+
+beforeEach(() => {
+  useFavoritesStore.setState({ favoritedIds: [] });
+});
+
+describe('useFavorite', () => {
+  it('returns false when the professional is not favorited', () => {
+    const { result } = renderHook(() => useFavorite('1'));
+    expect(result.current.isFavorited).toBe(false);
+  });
+
+  it('returns true after toggling on', () => {
+    const { result } = renderHook(() => useFavorite('1'));
+    act(() => result.current.toggle());
+    expect(result.current.isFavorited).toBe(true);
+  });
+
+  it('returns false after toggling off', () => {
+    const { result } = renderHook(() => useFavorite('1'));
+    act(() => result.current.toggle());
+    act(() => result.current.toggle());
+    expect(result.current.isFavorited).toBe(false);
+  });
+});

--- a/src/features/favorites/hooks/useFavorite.ts
+++ b/src/features/favorites/hooks/useFavorite.ts
@@ -1,23 +1,14 @@
-import { useState, useCallback } from 'react';
+import { useFavoritesStore } from '@store/favorites.store';
 
-// TODO: replace optimistic local state with a real API mutation once the
-// backend is ready:
-//   const mutation = useMutation({ mutationFn: () => apiClient.post(`/favorites/${id}`) });
+// TODO: when backend is ready, also call:
+//   apiClient.post(`/professionals/${id}/favorite`) or DELETE to unfavorite
 
-export function useFavorite(initialValue: boolean) {
-  const [isFavorited, setIsFavorited] = useState(initialValue);
-  const [isToggling, setIsToggling] = useState(false);
+export function useFavorite(professionalId: string) {
+  const isFavorited = useFavoritesStore((s) => s.isFavorited(professionalId));
+  const toggle = useFavoritesStore((s) => s.toggle);
 
-  const toggle = useCallback(async () => {
-    setIsToggling(true);
-    try {
-      // Optimistic update — swap to API call when backend is ready
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      setIsFavorited((prev) => !prev);
-    } finally {
-      setIsToggling(false);
-    }
-  }, []);
-
-  return { isFavorited, toggle, isToggling };
+  return {
+    isFavorited,
+    toggle: () => toggle(professionalId),
+  };
 }

--- a/src/features/favorites/hooks/useFavorite.ts
+++ b/src/features/favorites/hooks/useFavorite.ts
@@ -1,14 +1,34 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from '@services/api.client';
 import { useFavoritesStore } from '@store/favorites.store';
 
-// TODO: when backend is ready, also call:
-//   apiClient.post(`/professionals/${id}/favorite`) or DELETE to unfavorite
+async function addFavorite(id: string): Promise<void> {
+  await apiClient.post(`/professionals/${id}/favorite`);
+}
+
+async function removeFavorite(id: string): Promise<void> {
+  await apiClient.delete(`/professionals/${id}/favorite`);
+}
 
 export function useFavorite(professionalId: string) {
   const isFavorited = useFavoritesStore((s) => s.isFavorited(professionalId));
   const toggle = useFavoritesStore((s) => s.toggle);
 
+  const mutation = useMutation({
+    mutationFn: () => (isFavorited ? removeFavorite(professionalId) : addFavorite(professionalId)),
+    onMutate: () => {
+      // Optimistic update — flip immediately so the UI feels instant
+      toggle(professionalId);
+    },
+    onError: () => {
+      // Revert on failure
+      toggle(professionalId);
+    },
+  });
+
   return {
     isFavorited,
-    toggle: () => toggle(professionalId),
+    toggle: () => mutation.mutate(),
+    isToggling: mutation.isPending,
   };
 }

--- a/src/features/favorites/hooks/useFavorite.ts
+++ b/src/features/favorites/hooks/useFavorite.ts
@@ -1,0 +1,23 @@
+import { useState, useCallback } from 'react';
+
+// TODO: replace optimistic local state with a real API mutation once the
+// backend is ready:
+//   const mutation = useMutation({ mutationFn: () => apiClient.post(`/favorites/${id}`) });
+
+export function useFavorite(initialValue: boolean) {
+  const [isFavorited, setIsFavorited] = useState(initialValue);
+  const [isToggling, setIsToggling] = useState(false);
+
+  const toggle = useCallback(async () => {
+    setIsToggling(true);
+    try {
+      // Optimistic update — swap to API call when backend is ready
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      setIsFavorited((prev) => !prev);
+    } finally {
+      setIsToggling(false);
+    }
+  }, []);
+
+  return { isFavorited, toggle, isToggling };
+}

--- a/src/store/__tests__/favorites.store.test.ts
+++ b/src/store/__tests__/favorites.store.test.ts
@@ -1,0 +1,32 @@
+import { useFavoritesStore } from '../favorites.store';
+
+beforeEach(() => {
+  useFavoritesStore.setState({ favoritedIds: [] });
+});
+
+describe('favoritesStore', () => {
+  it('starts with no favorites', () => {
+    expect(useFavoritesStore.getState().isFavorited('1')).toBe(false);
+  });
+
+  it('toggle adds an id', () => {
+    useFavoritesStore.getState().toggle('1');
+    expect(useFavoritesStore.getState().isFavorited('1')).toBe(true);
+  });
+
+  it('toggle removes an already-favorited id', () => {
+    useFavoritesStore.getState().toggle('1');
+    useFavoritesStore.getState().toggle('1');
+    expect(useFavoritesStore.getState().isFavorited('1')).toBe(false);
+  });
+
+  it('manages multiple ids independently', () => {
+    useFavoritesStore.getState().toggle('1');
+    useFavoritesStore.getState().toggle('2');
+    expect(useFavoritesStore.getState().isFavorited('1')).toBe(true);
+    expect(useFavoritesStore.getState().isFavorited('2')).toBe(true);
+    useFavoritesStore.getState().toggle('1');
+    expect(useFavoritesStore.getState().isFavorited('1')).toBe(false);
+    expect(useFavoritesStore.getState().isFavorited('2')).toBe(true);
+  });
+});

--- a/src/store/favorites.store.ts
+++ b/src/store/favorites.store.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface FavoritesState {
+  favoritedIds: string[];
+  isFavorited: (id: string) => boolean;
+  toggle: (id: string) => void;
+}
+
+export const useFavoritesStore = create<FavoritesState>()(
+  persist(
+    (set, get) => ({
+      favoritedIds: [],
+
+      isFavorited: (id) => get().favoritedIds.includes(id),
+
+      toggle: (id) => {
+        set((state) => {
+          const already = state.favoritedIds.includes(id);
+          return {
+            favoritedIds: already
+              ? state.favoritedIds.filter((x) => x !== id)
+              : [...state.favoritedIds, id],
+          };
+        });
+      },
+    }),
+    {
+      name: 'favorites',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+);

--- a/src/types/__tests__/professional.test.ts
+++ b/src/types/__tests__/professional.test.ts
@@ -1,0 +1,19 @@
+import { PROFILE_TYPE_LABELS, SERVICE_TYPE_LABELS } from '../professional';
+
+describe('PROFILE_TYPE_LABELS', () => {
+  it('has a label for every profile type', () => {
+    expect(PROFILE_TYPE_LABELS.shop).toBe('Shop');
+    expect(PROFILE_TYPE_LABELS.service).toBe('Service');
+    expect(PROFILE_TYPE_LABELS.organizer).toBe('Organizer');
+    expect(PROFILE_TYPE_LABELS.classes_circles).toBe('Classes & Circles');
+  });
+});
+
+describe('SERVICE_TYPE_LABELS', () => {
+  it('has a label for every service type', () => {
+    expect(SERVICE_TYPE_LABELS.at_home).toBe('At home');
+    expect(SERVICE_TYPE_LABELS.has_studio).toBe('Has a studio');
+    expect(SERVICE_TYPE_LABELS.online).toBe('Online');
+    expect(SERVICE_TYPE_LABELS.travels_to_client).toBe('Travels to client');
+  });
+});

--- a/src/types/professional.ts
+++ b/src/types/professional.ts
@@ -1,0 +1,47 @@
+export type ProfileType = 'shop' | 'service' | 'organizer' | 'classes_circles';
+export type ProfileStatus =
+  | 'draft'
+  | 'pending_review'
+  | 'approved'
+  | 'changes_requested'
+  | 'rejected';
+export type PriceRange = '$' | '$$' | '$$$';
+export type ServiceTypeValue = 'at_home' | 'has_studio' | 'online' | 'travels_to_client';
+
+export interface Professional {
+  id: string;
+  businessName: string;
+  profileType: ProfileType;
+  category: string;
+  subcategories: string[];
+  serviceTypes: ServiceTypeValue[];
+  basedIn: string;
+  servesAreas: string[];
+  description: string;
+  inquiryEmail: string;
+  instagram?: string | undefined;
+  phone?: string | undefined;
+  website?: string | undefined;
+  bookingLink?: string | undefined;
+  priceRange?: PriceRange | undefined;
+  startingPrice?: string | undefined;
+  logoUri?: string | undefined;
+  status: ProfileStatus;
+  isFavorited: boolean;
+}
+
+// ── Display helpers ───────────────────────────────────────────────────────────
+
+export const PROFILE_TYPE_LABELS: Record<ProfileType, string> = {
+  shop: 'Shop',
+  service: 'Service',
+  organizer: 'Organizer',
+  classes_circles: 'Classes & Circles',
+};
+
+export const SERVICE_TYPE_LABELS: Record<ServiceTypeValue, string> = {
+  at_home: 'At home',
+  has_studio: 'Has a studio',
+  online: 'Online',
+  travels_to_client: 'Travels to client',
+};


### PR DESCRIPTION
Closes #10

## Summary

- `Professional` type with all profile fields + display label maps
- `useGetProfessional(id)` — TanStack Query hook (mock data, 3 sample profiles, ready for real API swap)
- `useFavorite()` — optimistic favorite toggle (local state, mutation-ready)
- `app/professional/[id].tsx` — full member-facing profile screen

## Screen sections

| Section | Details |
|---|---|
| Header | Back button + heart (favorite) toggle |
| Hero | Initials avatar, business name, profile type + price badge |
| Speciality | Category chip (accent) + subcategory chips |
| How they work | Service type chips (At home, Online, etc.) |
| Location | Based in + serves areas |
| About | Bio/description |
| Contact | Email, Instagram, Phone, Booking, Website — each opens native app via `Linking` |

## States handled
- **Loading** — spinner centered on screen
- **Error** — icon + message + "Try again" retry button
- **Favorite** — filled heart (crimson) / outline toggle with optimistic update

## Test plan
- [ ] Navigate to `/(root)/professional/1` — profile loads after ~600ms
- [ ] Navigate to `/(root)/professional/999` — error state appears with retry
- [ ] Tap heart — toggles between filled and outline
- [ ] Tap email row — mail client opens
- [ ] Tap Instagram row — browser/Instagram opens
- [ ] Tap phone row — phone dialer opens
- [ ] Tap back — returns to previous screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)