### PR TITLE
feat(#46): refactor onboarding to verified-profile application flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# Claude Code
+.claude/

--- a/app/(auth)/check-email.tsx
+++ b/app/(auth)/check-email.tsx
@@ -22,7 +22,7 @@ export default function CheckEmailScreen() {
     } = supabase.auth.onAuthStateChange((event, session) => {
       if ((event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') && session) {
         void setAuth().then(() => {
-          if (role === 'professional') {
+          if (role === 'verified') {
             router.replace('/(auth)/professional-profile');
           } else {
             router.replace('/(tabs)');
@@ -41,7 +41,7 @@ export default function CheckEmailScreen() {
       } = await supabase.auth.getSession();
       if (session) {
         await setAuth();
-        if (role === 'professional') {
+        if (role === 'verified') {
           router.replace('/(auth)/professional-profile');
         } else {
           router.replace('/(tabs)');

--- a/app/(auth)/professional-profile.tsx
+++ b/app/(auth)/professional-profile.tsx
@@ -1,7 +1,6 @@
 import { KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { colors } from '@theme/colors';
 import { ProfileWizard } from '@features/profile/components/ProfileWizard';
 import { supabase } from '@services/supabase.client';
 import { useAuthStore } from '@store/auth.store';
@@ -34,6 +33,6 @@ export default function ProfessionalProfileScreen() {
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: colors.burgundy.deep },
+  safe: { flex: 1, backgroundColor: '#faf6f0' },
   flex: { flex: 1 },
 });

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -10,41 +10,33 @@ import {
 import { useRouter } from 'expo-router';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Text, Button, Input, BackButton } from '@components/ui';
 import { spacing } from '@theme/spacing';
 import { useAuth } from '@features/auth';
 import { signUpSchema, type SignUpFormData } from '@features/auth/schemas/auth.schema';
 
-type Role = 'user' | 'professional';
-const ROLES: { value: Role; label: string; description: string }[] = [
-  { value: 'user', label: 'Member', description: 'Discover events & professionals' },
-  { value: 'professional', label: 'Professional', description: 'Publish events & a profile' },
-];
-
 export default function SignUpScreen() {
   const router = useRouter();
   const { signUp, isLoading } = useAuth();
+  const [applyingForVerified, setApplyingForVerified] = useState(false);
+  const [serverError, setServerError] = useState<string | undefined>(undefined);
 
   const {
     control,
     handleSubmit,
-    watch,
-    setValue,
     formState: { errors },
   } = useForm<SignUpFormData>({
     resolver: zodResolver(signUpSchema),
-    defaultValues: { displayName: '', email: '', role: 'user', password: '', confirmPassword: '' },
+    defaultValues: { displayName: '', email: '', password: '', confirmPassword: '' },
   });
-
-  const selectedRole = watch('role');
-  const [serverError, setServerError] = useState<string | undefined>(undefined);
 
   const onSubmit = async (data: SignUpFormData) => {
     setServerError(undefined);
     try {
       await signUp(data.email, data.password, data.displayName);
-      if (data.role === 'professional') {
+      if (applyingForVerified) {
         router.replace('/(auth)/professional-profile');
       } else {
         router.replace('/(tabs)');
@@ -78,31 +70,21 @@ export default function SignUpScreen() {
             </Text>
           </View>
 
-          <View style={styles.roleSection}>
-            <Text variant="overline" style={styles.subtitle}>
-              I am joining as
-            </Text>
-            <View style={styles.roleRow}>
-              {ROLES.map(({ value, label, description }) => {
-                const isSelected = selectedRole === value;
-                return (
-                  <TouchableOpacity
-                    key={value}
-                    onPress={() => setValue('role', value)}
-                    style={[styles.roleCard, isSelected && styles.roleCardSelected]}
-                    activeOpacity={0.8}
-                  >
-                    <Text style={[styles.roleLabel, isSelected && styles.roleLabelSelected]}>
-                      {label}
-                    </Text>
-                    <Text style={[styles.roleDesc, isSelected && styles.roleDescSelected]}>
-                      {description}
-                    </Text>
-                  </TouchableOpacity>
-                );
-              })}
+          {/* Verified profile intent badge */}
+          {applyingForVerified && (
+            <View style={styles.verifiedBadge}>
+              <View style={styles.verifiedBadgeLeft}>
+                <Ionicons name="checkmark-circle" size={15} color="#2F0A0A" />
+                <Text style={styles.verifiedBadgeText}>Applying for a verified profile</Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => setApplyingForVerified(false)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <Ionicons name="close" size={16} color="#2F0A0A" />
+              </TouchableOpacity>
             </View>
-          </View>
+          )}
 
           <Controller
             control={control}
@@ -184,6 +166,22 @@ export default function SignUpScreen() {
             textColor="#ffffff"
           />
 
+          {/* Verified profile application link */}
+          {!applyingForVerified && (
+            <TouchableOpacity
+              onPress={() => setApplyingForVerified(true)}
+              style={styles.verifiedLink}
+              activeOpacity={0.7}
+            >
+              <Text variant="caption" style={styles.verifiedLinkLabel}>
+                Are you an organizer, business, or community group?
+              </Text>
+              <Text variant="caption" style={styles.verifiedLinkCta}>
+                Apply for a verified profile →
+              </Text>
+            </TouchableOpacity>
+          )}
+
           <TouchableOpacity onPress={() => router.push('/(auth)/sign-in')} style={styles.footer}>
             <Text variant="caption" style={styles.footerText}>
               {'Already have an account?  '}
@@ -206,30 +204,48 @@ const styles = StyleSheet.create({
   heading: { color: '#1a1212' },
   subtitle: { color: 'rgba(26, 18, 18, 0.45)' },
 
-  roleSection: { marginBottom: spacing[10], gap: spacing[4] },
-  roleRow: { flexDirection: 'row', gap: spacing[3] },
-  roleCard: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: 'rgba(160, 122, 95, 0.30)',
+  verifiedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#e8ddd4',
     borderRadius: 8,
-    padding: spacing[4],
-    gap: spacing[1],
-    backgroundColor: 'transparent',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    marginBottom: spacing[6],
   },
-  roleCardSelected: { borderColor: '#2F0A0A', backgroundColor: 'rgba(40, 2, 10, 0.04)' },
-  roleLabel: {
-    fontSize: 13,
+  verifiedBadgeLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  verifiedBadgeText: {
+    fontSize: 12,
     fontWeight: '600',
-    color: 'rgba(26, 18, 18, 0.55)',
-    letterSpacing: 0.3,
+    color: '#2F0A0A',
+    letterSpacing: 0.2,
   },
-  roleLabelSelected: { color: '#1a1212' },
-  roleDesc: { fontSize: 11, color: 'rgba(26, 18, 18, 0.45)', lineHeight: 15, opacity: 0.7 },
-  roleDescSelected: { color: 'rgba(26, 18, 18, 0.55)', opacity: 1 },
 
   serverError: { color: '#e57373', textAlign: 'center', marginTop: spacing[2] },
   cta: { width: '100%', marginTop: spacing[4], backgroundColor: '#2F0A0A' },
+
+  verifiedLink: {
+    marginTop: spacing[6],
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingVertical: spacing[3],
+  },
+  verifiedLinkLabel: {
+    color: 'rgba(26, 18, 18, 0.40)',
+    textAlign: 'center',
+  },
+  verifiedLinkCta: {
+    color: 'rgba(47, 10, 10, 0.65)',
+    fontWeight: '600',
+    textAlign: 'center',
+    letterSpacing: 0.1,
+  },
+
   footer: { marginTop: spacing[8], alignItems: 'center' },
   footerText: { color: 'rgba(26, 18, 18, 0.45)' },
   footerLink: { color: '#2F0A0A', fontWeight: '600' },

--- a/app/(auth)/thank-you.tsx
+++ b/app/(auth)/thank-you.tsx
@@ -31,13 +31,12 @@ export default function ThankYouScreen() {
         </Text>
 
         <Text variant="bodySm" style={styles.body}>
-          Thank you for joining Medina Collective. We have received your profile request and will
-          review it as soon as possible.
+          Thank you for joining Medina Collective. We have received your verified profile
+          application and will review it as soon as possible.
         </Text>
 
         <Text variant="bodySm" style={styles.body}>
-          You will receive an email once your profile is approved. In the meantime, feel free to
-          explore the app.
+          You will receive an email once your profile is approved and visible to the community.
         </Text>
 
         <Text variant="caption" style={styles.note}>

--- a/src/features/auth/__tests__/auth.schema.test.ts
+++ b/src/features/auth/__tests__/auth.schema.test.ts
@@ -31,23 +31,12 @@ describe('signUpSchema', () => {
   const valid = {
     displayName: 'Wissem',
     email: 'wissem@example.com',
-    role: 'user' as const,
     password: 'Password1',
     confirmPassword: 'Password1',
   };
 
   it('accepts a valid member sign-up', () => {
     expect(signUpSchema.safeParse(valid).success).toBe(true);
-  });
-
-  it('accepts a professional role', () => {
-    const result = signUpSchema.safeParse({ ...valid, role: 'professional' });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects an invalid role', () => {
-    const result = signUpSchema.safeParse({ ...valid, role: 'admin' });
-    expect(result.success).toBe(false);
   });
 
   it('rejects a display name shorter than 2 characters', () => {

--- a/src/features/auth/schemas/auth.schema.ts
+++ b/src/features/auth/schemas/auth.schema.ts
@@ -9,7 +9,6 @@ export const signUpSchema = z
   .object({
     displayName: z.string().min(2, 'Name must be at least 2 characters').max(50),
     email: z.email(),
-    role: z.enum(['user', 'professional']),
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters')

--- a/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
+++ b/src/features/discover/components/__tests__/ProfessionalCard.test.tsx
@@ -16,10 +16,11 @@ jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }));
 const base: Professional = {
   id: '1',
   businessName: 'Henna by Fatima',
-  profileType: 'service',
+  profileType: 'freelancer_service',
+  monetizationType: 'for_profit',
   category: 'Beauty',
   subcategories: ['Henna', 'Makeup'],
-  serviceTypes: ['at_home'],
+  serviceTypes: ['in_person'],
   basedIn: 'Montreal',
   servesAreas: ['Montreal'],
   description: 'Test description',
@@ -37,7 +38,7 @@ describe('ProfessionalCard', () => {
     expect(getByText('Henna by Fatima')).toBeTruthy();
     expect(getByText('Beauty · Henna, Makeup')).toBeTruthy();
     expect(getByText('Montreal')).toBeTruthy();
-    expect(getByText('Service')).toBeTruthy();
+    expect(getByText('Freelancer / service provider')).toBeTruthy();
   });
 
   it('renders avatar initials from the first two words', () => {

--- a/src/features/discover/components/__tests__/ProfessionalList.test.tsx
+++ b/src/features/discover/components/__tests__/ProfessionalList.test.tsx
@@ -16,7 +16,8 @@ const mockRetry = jest.fn().mockResolvedValue(undefined);
 const professional: Professional = {
   id: '1',
   businessName: 'Henna by Fatima',
-  profileType: 'service',
+  profileType: 'freelancer_service',
+  monetizationType: 'for_profit',
   category: 'Beauty',
   subcategories: [],
   serviceTypes: [],

--- a/src/features/discover/hooks/useProfessional.ts
+++ b/src/features/discover/hooks/useProfessional.ts
@@ -1,6 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@services/supabase.client';
-import type { Professional, ProfileType, MonetizationType, ServiceTypeValue } from '@app-types/professional';
+import type {
+  Professional,
+  ProfileType,
+  MonetizationType,
+  ServiceTypeValue,
+} from '@app-types/professional';
 import type { Database } from '@app-types/supabase';
 
 type ProfessionalRow = Database['public']['Tables']['professionals']['Row'];

--- a/src/features/discover/hooks/useProfessional.ts
+++ b/src/features/discover/hooks/useProfessional.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@services/supabase.client';
-import type { Professional, ServiceTypeValue } from '@app-types/professional';
+import type { Professional, ProfileType, MonetizationType, ServiceTypeValue } from '@app-types/professional';
 import type { Database } from '@app-types/supabase';
 
 type ProfessionalRow = Database['public']['Tables']['professionals']['Row'];
@@ -9,7 +9,8 @@ function rowToProfessional(row: ProfessionalRow): Professional {
   return {
     id: row.id,
     businessName: row.business_name,
-    profileType: row.profile_type,
+    profileType: row.profile_type as ProfileType,
+    monetizationType: (row.monetization_type ?? 'for_profit') as MonetizationType,
     category: row.category,
     subcategories: row.subcategories,
     serviceTypes: row.service_types as ServiceTypeValue[],

--- a/src/features/profile/components/BusinessLogoPicker.tsx
+++ b/src/features/profile/components/BusinessLogoPicker.tsx
@@ -1,7 +1,6 @@
 import { View, TouchableOpacity, Image, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { fontSize } from '@theme/typography';
 
@@ -37,7 +36,7 @@ export function BusinessLogoPicker({
           )}
         </View>
         <View style={styles.badge}>
-          <Ionicons name="camera" size={14} color={colors.burgundy.deep} />
+          <Ionicons name="camera" size={14} color="#ffffff" />
         </View>
       </TouchableOpacity>
       <Text variant="caption" style={styles.hint}>
@@ -61,9 +60,9 @@ const styles = StyleSheet.create({
     width: 96,
     height: 96,
     borderRadius: 48,
-    backgroundColor: colors.burgundy.raised,
+    backgroundColor: '#fff9f5',
     borderWidth: 2,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
@@ -75,7 +74,7 @@ const styles = StyleSheet.create({
   initials: {
     fontSize: fontSize.xl,
     fontWeight: '700',
-    color: '#CEC1AE',
+    color: '#2F0A0A',
     letterSpacing: 1,
   },
   badge: {
@@ -85,13 +84,13 @@ const styles = StyleSheet.create({
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: '#CEC1AE',
+    backgroundColor: '#2F0A0A',
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 2,
-    borderColor: colors.burgundy.deep,
+    borderColor: '#faf6f0',
   },
   hint: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
   },
 });

--- a/src/features/profile/components/BusinessTypeSelector.tsx
+++ b/src/features/profile/components/BusinessTypeSelector.tsx
@@ -18,7 +18,7 @@ export function BusinessTypeSelector({
   return (
     <View style={styles.container}>
       <Text variant="overline" style={styles.label}>
-        Profile type
+        Which best describes you?
       </Text>
       <View style={styles.grid}>
         {PROFILE_TYPES.map(({ value: typeValue, label, description }) => {
@@ -55,44 +55,42 @@ const styles = StyleSheet.create({
   },
   label: {
     marginBottom: spacing[3],
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   grid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
     gap: spacing[2],
   },
   card: {
-    width: '48%',
+    width: '100%',
     paddingVertical: spacing[4],
     paddingHorizontal: spacing[4],
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
     borderRadius: 8,
     gap: spacing[1],
   },
   cardSelected: {
-    borderColor: '#CEC1AE',
-    backgroundColor: colors.burgundy.raised,
+    borderColor: '#2F0A0A',
+    backgroundColor: '#fff9f5',
   },
   cardLabel: {
     fontSize: 13,
     fontWeight: '600',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
     letterSpacing: 0.2,
   },
   cardLabelSelected: {
-    color: '#CEC1AE',
+    color: '#1a1212',
   },
   cardDesc: {
     fontSize: 11,
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
     lineHeight: 15,
     opacity: 0.7,
   },
   cardDescSelected: {
-    color: '#CEC1AE',
-    opacity: 0.8,
+    color: 'rgba(26, 18, 18, 0.55)',
+    opacity: 1,
   },
   error: {
     marginTop: spacing[2],

--- a/src/features/profile/components/LocationStep.tsx
+++ b/src/features/profile/components/LocationStep.tsx
@@ -1,6 +1,5 @@
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { BASED_IN_OPTIONS, SERVES_AREAS_OPTIONS } from '../schemas/professional-profile.schema';
 import { SelectableList } from './SelectableList';
@@ -72,7 +71,7 @@ const styles = StyleSheet.create({
     gap: spacing[3],
   },
   sectionLabel: {
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
     marginBottom: spacing[1],
   },
   chips: {
@@ -85,23 +84,23 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
   },
   chipSelected: {
-    backgroundColor: colors.burgundy.raised,
-    borderColor: '#CEC1AE',
+    backgroundColor: '#fff9f5',
+    borderColor: '#2F0A0A',
   },
   chipLabel: {
     fontSize: 13,
     fontWeight: '500',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
   },
   chipLabelSelected: {
-    color: '#CEC1AE',
+    color: '#1a1212',
     fontWeight: '600',
   },
   error: {
     marginTop: spacing[1],
-    color: colors.error[500],
+    color: '#ef4444',
   },
 });

--- a/src/features/profile/components/MonetizationTypeSelector.tsx
+++ b/src/features/profile/components/MonetizationTypeSelector.tsx
@@ -1,0 +1,125 @@
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { Text } from '@components/ui';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+import { MONETIZATION_TYPES, type MonetizationType } from '../schemas/professional-profile.schema';
+
+interface MonetizationTypeSelectorProps {
+  value: MonetizationType | undefined;
+  onChange: (value: MonetizationType) => void;
+  error?: string | undefined;
+}
+
+export function MonetizationTypeSelector({
+  value,
+  onChange,
+  error,
+}: Readonly<MonetizationTypeSelectorProps>) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.list}>
+        {MONETIZATION_TYPES.map(({ value: typeValue, label, description }) => {
+          const isSelected = value === typeValue;
+          return (
+            <TouchableOpacity
+              key={typeValue}
+              onPress={() => onChange(typeValue)}
+              activeOpacity={0.8}
+              style={[styles.card, isSelected && styles.cardSelected]}
+            >
+              <View style={styles.cardInner}>
+                <View style={[styles.radio, isSelected && styles.radioSelected]}>
+                  {isSelected && <View style={styles.radioDot} />}
+                </View>
+                <View style={styles.cardText}>
+                  <Text style={[styles.cardLabel, isSelected && styles.cardLabelSelected]}>
+                    {label}
+                  </Text>
+                  <Text style={[styles.cardDesc, isSelected && styles.cardDescSelected]}>
+                    {description}
+                  </Text>
+                </View>
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+      {error !== undefined && error.length > 0 && (
+        <Text variant="caption" style={styles.error}>
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: spacing[8],
+  },
+  list: {
+    gap: spacing[3],
+  },
+  card: {
+    paddingVertical: spacing[4],
+    paddingHorizontal: spacing[4],
+    borderWidth: 1,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
+    borderRadius: 10,
+  },
+  cardSelected: {
+    borderColor: '#2F0A0A',
+    backgroundColor: '#fff9f5',
+  },
+  cardInner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[3],
+  },
+  radio: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    borderWidth: 1.5,
+    borderColor: 'rgba(160, 122, 95, 0.40)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 1,
+  },
+  radioSelected: {
+    borderColor: '#2F0A0A',
+  },
+  radioDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#2F0A0A',
+  },
+  cardText: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  cardLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: 'rgba(26, 18, 18, 0.55)',
+    letterSpacing: 0.1,
+  },
+  cardLabelSelected: {
+    color: '#1a1212',
+  },
+  cardDesc: {
+    fontSize: 12,
+    color: 'rgba(26, 18, 18, 0.45)',
+    lineHeight: 16,
+    opacity: 0.7,
+  },
+  cardDescSelected: {
+    color: 'rgba(26, 18, 18, 0.55)',
+    opacity: 1,
+  },
+  error: {
+    marginTop: spacing[2],
+    color: colors.error[500],
+  },
+});

--- a/src/features/profile/components/ProfilePreviewCard.tsx
+++ b/src/features/profile/components/ProfilePreviewCard.tsx
@@ -1,11 +1,11 @@
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { fontSize } from '@theme/typography';
 import {
   PROFILE_TYPES,
+  MONETIZATION_TYPES,
   SERVICE_TYPE_OPTIONS,
   type ProfessionalProfileFormData,
 } from '../schemas/professional-profile.schema';
@@ -53,6 +53,10 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
   const profileTypeLabel =
     PROFILE_TYPES.find((t) => t.value === data.profileType)?.label ?? data.profileType;
 
+  const monetizationLabel =
+    MONETIZATION_TYPES.find((t) => t.value === data.monetizationType)?.label ??
+    data.monetizationType;
+
   const serviceTypeLabels = data.serviceTypes.map(
     (v) => SERVICE_TYPE_OPTIONS.find((o) => o.value === v)?.label ?? v,
   );
@@ -76,8 +80,8 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
 
       <View style={styles.divider} />
 
-      {/* Profile Type */}
-      <SectionRow label="Profile Type" onEdit={() => onEditStep(0)}>
+      {/* Profile Identity */}
+      <SectionRow label="Profile type" onEdit={() => onEditStep(0)}>
         <View style={styles.pills}>
           <View style={styles.pill}>
             <Text style={styles.pillText}>{profileTypeLabel}</Text>
@@ -85,8 +89,19 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
         </View>
       </SectionRow>
 
+      {/* Monetization */}
+      {data.monetizationType !== undefined && (
+        <SectionRow label="How you operate" onEdit={() => onEditStep(1)}>
+          <View style={styles.pills}>
+            <View style={[styles.pill, styles.pillMuted]}>
+              <Text style={styles.pillText}>{monetizationLabel}</Text>
+            </View>
+          </View>
+        </SectionRow>
+      )}
+
       {/* Category */}
-      <SectionRow label="Category" onEdit={() => onEditStep(1)}>
+      <SectionRow label="Category" onEdit={() => onEditStep(2)}>
         {data.category.length > 0 ? (
           <View style={styles.pills}>
             <View style={[styles.pill, styles.pillAccent]}>
@@ -107,7 +122,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
 
       {/* Service Type */}
       {serviceTypeLabels.length > 0 && (
-        <SectionRow label="Service Type" onEdit={() => onEditStep(3)}>
+        <SectionRow label="Delivery" onEdit={() => onEditStep(4)}>
           <View style={styles.pills}>
             {serviceTypeLabels.map((label) => (
               <View key={label} style={styles.pill}>
@@ -119,11 +134,11 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
       )}
 
       {/* Location */}
-      <SectionRow label="Location" onEdit={() => onEditStep(4)}>
+      <SectionRow label="Location" onEdit={() => onEditStep(5)}>
         {data.basedIn.length > 0 ? (
           <View style={styles.locationBlock}>
             <View style={styles.contactRow}>
-              <Ionicons name="location-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="location-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 Based in {data.basedIn}
               </Text>
@@ -142,7 +157,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
       </SectionRow>
 
       {/* About & Contact */}
-      <SectionRow label="About & Contact" onEdit={() => onEditStep(5)}>
+      <SectionRow label="About & Contact" onEdit={() => onEditStep(6)}>
         {data.description.length > 0 && (
           <Text variant="bodySm" style={styles.description}>
             {data.description}
@@ -151,7 +166,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
         <View style={styles.contactList}>
           {data.priceRange !== undefined && (
             <View style={styles.contactRow}>
-              <Ionicons name="pricetag-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="pricetag-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 {data.priceRange}
                 {data.startingPrice !== undefined && data.startingPrice.length > 0
@@ -162,7 +177,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
           )}
           {data.inquiryEmail.length > 0 && (
             <View style={styles.contactRow}>
-              <Ionicons name="mail-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="mail-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 {data.inquiryEmail}
               </Text>
@@ -170,7 +185,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
           )}
           {data.instagram !== undefined && data.instagram.length > 0 && (
             <View style={styles.contactRow}>
-              <Ionicons name="logo-instagram" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="logo-instagram" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 @{data.instagram}
               </Text>
@@ -178,7 +193,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
           )}
           {data.phone !== undefined && data.phone.length > 0 && (
             <View style={styles.contactRow}>
-              <Ionicons name="call-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="call-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 {data.phone}
               </Text>
@@ -186,7 +201,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
           )}
           {data.website !== undefined && data.website.length > 0 && (
             <View style={styles.contactRow}>
-              <Ionicons name="link-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="link-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 {data.website}
               </Text>
@@ -194,7 +209,7 @@ export function ProfilePreviewCard({ data, onEditStep }: Readonly<ProfilePreview
           )}
           {data.bookingLink !== undefined && data.bookingLink.length > 0 && (
             <View style={styles.contactRow}>
-              <Ionicons name="calendar-outline" size={13} color={colors.burgundy.muted} />
+              <Ionicons name="calendar-outline" size={13} color="rgba(26, 18, 18, 0.45)" />
               <Text variant="caption" style={styles.contactText}>
                 {data.bookingLink}
               </Text>
@@ -217,16 +232,16 @@ const styles = StyleSheet.create({
     width: 64,
     height: 64,
     borderRadius: 32,
-    backgroundColor: colors.burgundy.raised,
+    backgroundColor: '#fff9f5',
     borderWidth: 2,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
     justifyContent: 'center',
     alignItems: 'center',
   },
   initials: {
     fontSize: fontSize.lg,
     fontWeight: '700',
-    color: '#CEC1AE',
+    color: '#2F0A0A',
     letterSpacing: 1,
   },
   headerText: {
@@ -234,14 +249,14 @@ const styles = StyleSheet.create({
     gap: spacing[1],
   },
   businessName: {
-    color: '#CEC1AE',
+    color: '#1a1212',
   },
   profileTypeBadge: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   divider: {
     height: 1,
-    backgroundColor: colors.burgundy.surface,
+    backgroundColor: '#e5e1dc',
     marginBottom: spacing[6],
   },
   sectionRow: {
@@ -254,10 +269,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   sectionLabel: {
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   editLink: {
-    color: '#CEC1AE',
+    color: '#2F0A0A',
     fontWeight: '600',
     letterSpacing: 0,
   },
@@ -270,16 +285,20 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[1],
     paddingHorizontal: spacing[3],
     borderRadius: 20,
-    backgroundColor: colors.burgundy.raised,
+    backgroundColor: '#fff9f5',
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
   },
   pillAccent: {
-    borderColor: '#CEC1AE',
+    borderColor: '#2F0A0A',
+  },
+  pillMuted: {
+    borderColor: 'transparent',
+    backgroundColor: '#f3f0eb',
   },
   pillText: {
     fontSize: 12,
-    color: '#CEC1AE',
+    color: '#1a1212',
     fontWeight: '500',
   },
   pillTextAccent: {
@@ -289,13 +308,12 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   emptyText: {
-    color: colors.burgundy.raised,
+    color: 'rgba(26, 18, 18, 0.35)',
     fontStyle: 'italic',
   },
   description: {
-    color: '#CEC1AE',
+    color: 'rgba(26, 18, 18, 0.75)',
     lineHeight: 20,
-    opacity: 0.85,
   },
   contactList: {
     gap: spacing[2],
@@ -306,6 +324,6 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   contactText: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
   },
 });

--- a/src/features/profile/components/ProfileWizard.tsx
+++ b/src/features/profile/components/ProfileWizard.tsx
@@ -11,6 +11,7 @@ import { fontSize } from '@theme/typography';
 import {
   professionalProfileSchema,
   CATEGORY_STEP_COPY,
+  SERVICE_TYPE_STEP_COPY,
   PRICE_RANGES,
   STEP_FIELDS,
   type ProfessionalProfileFormData,
@@ -18,6 +19,7 @@ import {
 import { StepIndicator } from '@features/profile/components/StepIndicator';
 import { BusinessLogoPicker } from '@features/profile/components/BusinessLogoPicker';
 import { BusinessTypeSelector } from '@features/profile/components/BusinessTypeSelector';
+import { MonetizationTypeSelector } from '@features/profile/components/MonetizationTypeSelector';
 import { CategorySelector } from '@features/profile/components/CategorySelector';
 import { SubcategorySelector } from '@features/profile/components/SubcategorySelector';
 import { ServiceTypeSelector } from '@features/profile/components/ServiceTypeSelector';
@@ -26,7 +28,7 @@ import { ProfilePreviewCard } from '@features/profile/components/ProfilePreviewC
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
-const TOTAL_STEPS = 7;
+const TOTAL_STEPS = 8;
 
 // ── Props ──────────────────────────────────────────────────────────────────────
 
@@ -81,8 +83,25 @@ export function ProfileWizard({
 
   const scrollToTop = () => scrollRef.current?.scrollTo({ y: 0, animated: false });
 
-  // Step 2 (index 2) is Subcategory — only relevant for 'service' profile type
-  const shouldSkipSubcategory = watchedValues.profileType !== 'service';
+  // Step 3 (subcategory) — only for freelancer_service
+  const shouldSkipSubcategory = watchedValues.profileType !== 'freelancer_service';
+
+  // Step 4 (how you work / delivery mode) — only for freelancer_service
+  const shouldSkipServiceType = watchedValues.profileType !== 'freelancer_service';
+
+  const getNextStep = (from: number): number => {
+    const next = from + 1;
+    if (next === 3 && shouldSkipSubcategory) return getNextStep(3);
+    if (next === 4 && shouldSkipServiceType) return getNextStep(4);
+    return next;
+  };
+
+  const getPrevStep = (from: number): number => {
+    const prev = from - 1;
+    if (prev === 3 && shouldSkipSubcategory) return getPrevStep(3);
+    if (prev === 4 && shouldSkipServiceType) return getPrevStep(4);
+    return prev;
+  };
 
   const handleNext = async () => {
     const fields = STEP_FIELDS[currentStep];
@@ -90,11 +109,8 @@ export function ProfileWizard({
       const isValid = await trigger(fields);
       if (!isValid) return;
     }
-    const nextStep = currentStep + 1;
-    // Skip subcategory step for non-service types
-    const resolvedNext = nextStep === 2 && shouldSkipSubcategory ? 3 : nextStep;
     scrollToTop();
-    setCurrentStep(resolvedNext);
+    setCurrentStep(getNextStep(currentStep));
   };
 
   const handleBack = () => {
@@ -106,11 +122,8 @@ export function ProfileWizard({
       }
       return;
     }
-    const prevStep = currentStep - 1;
-    // Skip subcategory step for non-service types when going back
-    const resolvedPrev = prevStep === 2 && shouldSkipSubcategory ? 1 : prevStep;
     scrollToTop();
-    setCurrentStep(resolvedPrev);
+    setCurrentStep(getPrevStep(currentStep));
   };
 
   const onSubmitHandler: SubmitHandler<ProfessionalProfileFormData> = async (data) => {
@@ -121,6 +134,14 @@ export function ProfileWizard({
       setIsSubmitting(false);
     }
   };
+
+  // Pricing fields visible for for-profit and mixed profiles
+  const showPricingFields = watchedValues.monetizationType === 'for_profit';
+
+  const bookingLinkLabel =
+    watchedValues.monetizationType === 'nonprofit'
+      ? 'Registration or contact link (optional)'
+      : 'Booking link (optional)';
 
   const isLastStep = currentStep === TOTAL_STEPS - 1;
 
@@ -134,12 +155,12 @@ export function ProfileWizard({
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {/* ── Step 0: Profile Type ──────────────────────────────────────────── */}
+        {/* ── Step 0: Identity ──────────────────────────────────────────────── */}
         {currentStep === 0 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
-                {"Let's set up\nyour profile"}
+                {"Let's set up\nyour verified profile"}
               </Text>
               <Text variant="bodySm" style={styles.stepSubtitle}>
                 Tell us who you are so the right people can find you.
@@ -181,7 +202,8 @@ export function ProfileWizard({
               name="businessName"
               render={({ field: { onChange, value } }) => (
                 <Input
-                  label="Business or profile name"
+                  variant="light"
+                  label="Profile name"
                   placeholder="Your name, brand, or initiative"
                   value={value}
                   onChangeText={onChange}
@@ -205,8 +227,34 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 1: Category ──────────────────────────────────────────────── */}
+        {/* ── Step 1: Monetization ──────────────────────────────────────────── */}
         {currentStep === 1 && (
+          <View>
+            <View style={styles.stepHeader}>
+              <Text variant="heading2" style={styles.stepTitle}>
+                How do you operate?
+              </Text>
+              <Text variant="bodySm" style={styles.stepSubtitle}>
+                This helps us tailor your profile and ensures accurate admin review.
+              </Text>
+            </View>
+
+            <Controller
+              control={control}
+              name="monetizationType"
+              render={({ field: { value, onChange } }) => (
+                <MonetizationTypeSelector
+                  value={value}
+                  onChange={onChange}
+                  error={errors.monetizationType?.message}
+                />
+              )}
+            />
+          </View>
+        )}
+
+        {/* ── Step 2: Category ──────────────────────────────────────────────── */}
+        {currentStep === 2 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
@@ -230,7 +278,6 @@ export function ProfileWizard({
                   value={value}
                   onChange={(cat) => {
                     onChange(cat);
-                    // Reset subcategories when category changes
                     setValue('subcategories', []);
                   }}
                   error={errors.category?.message}
@@ -240,8 +287,8 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 2: Subcategory (service only) ───────────────────────────── */}
-        {currentStep === 2 && (
+        {/* ── Step 3: Subcategory (freelancer_service only) ─────────────────── */}
+        {currentStep === 3 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
@@ -260,15 +307,21 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 3: Service Type ─────────────────────────────────────────── */}
-        {currentStep === 3 && (
+        {/* ── Step 4: Delivery mode (freelancer_service + class_workshop_host) ─ */}
+        {currentStep === 4 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
-                How do you work?
+                {watchedValues.profileType !== undefined &&
+                SERVICE_TYPE_STEP_COPY[watchedValues.profileType] !== undefined
+                  ? SERVICE_TYPE_STEP_COPY[watchedValues.profileType]!.title
+                  : 'How do you work?'}
               </Text>
               <Text variant="bodySm" style={styles.stepSubtitle}>
-                Select all that apply. Optional but helps people find you.
+                {watchedValues.profileType !== undefined &&
+                SERVICE_TYPE_STEP_COPY[watchedValues.profileType] !== undefined
+                  ? SERVICE_TYPE_STEP_COPY[watchedValues.profileType]!.subtitle
+                  : 'Select all that apply.'}
               </Text>
             </View>
 
@@ -279,8 +332,8 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 4: Location ─────────────────────────────────────────────── */}
-        {currentStep === 4 && (
+        {/* ── Step 5: Location ──────────────────────────────────────────────── */}
+        {currentStep === 5 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
@@ -301,8 +354,8 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 5: About & Contact ──────────────────────────────────────── */}
-        {currentStep === 5 && (
+        {/* ── Step 6: About & Contact ───────────────────────────────────────── */}
+        {currentStep === 6 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
@@ -352,51 +405,55 @@ export function ProfileWizard({
               )}
             />
 
-            {/* Price range */}
-            <View style={styles.fieldGroup}>
-              <Text variant="overline" style={styles.groupLabel}>
-                Price range (optional)
-              </Text>
-              <Controller
-                control={control}
-                name="priceRange"
-                render={({ field: { value, onChange } }) => (
-                  <View style={styles.chipRow}>
-                    {PRICE_RANGES.map((range) => {
-                      const isSelected = value === range;
-                      return (
-                        <View
-                          key={range}
-                          style={[styles.priceChip, isSelected && styles.priceChipSelected]}
-                        >
-                          <Text
-                            onPress={() => onChange(isSelected ? undefined : range)}
-                            style={[styles.priceLabel, isSelected && styles.priceLabelSelected]}
-                          >
-                            {range}
-                          </Text>
-                        </View>
-                      );
-                    })}
-                  </View>
-                )}
-              />
-            </View>
+            {/* Pricing — only for for-profit and mixed profiles */}
+            {showPricingFields && (
+              <>
+                <View style={styles.fieldGroup}>
+                  <Text variant="overline" style={styles.groupLabel}>
+                    Price range (optional)
+                  </Text>
+                  <Controller
+                    control={control}
+                    name="priceRange"
+                    render={({ field: { value, onChange } }) => (
+                      <View style={styles.chipRow}>
+                        {PRICE_RANGES.map((range) => {
+                          const isSelected = value === range;
+                          return (
+                            <View
+                              key={range}
+                              style={[styles.priceChip, isSelected && styles.priceChipSelected]}
+                            >
+                              <Text
+                                onPress={() => onChange(isSelected ? undefined : range)}
+                                style={[styles.priceLabel, isSelected && styles.priceLabelSelected]}
+                              >
+                                {range}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+                    )}
+                  />
+                </View>
 
-            {/* Starting price */}
-            <Controller
-              control={control}
-              name="startingPrice"
-              render={({ field: { onChange, value } }) => (
-                <Input
-                  label="Starting price (optional)"
-                  placeholder="e.g. $50, $25/hr"
-                  value={value}
-                  onChangeText={onChange}
-                  autoCapitalize="none"
+                <Controller
+                  control={control}
+                  name="startingPrice"
+                  render={({ field: { onChange, value } }) => (
+                    <Input
+                      variant="light"
+                      label="Starting price (optional)"
+                      placeholder="e.g. $50, $25/hr"
+                      value={value}
+                      onChangeText={onChange}
+                      autoCapitalize="none"
+                    />
+                  )}
                 />
-              )}
-            />
+              </>
+            )}
 
             {/* Public inquiry email */}
             <Controller
@@ -405,8 +462,9 @@ export function ProfileWizard({
               render={({ field: { onChange, value } }) => (
                 <View>
                   <Input
+                    variant="light"
                     label="Public inquiry email"
-                    placeholder="hello@yourbusiness.com"
+                    placeholder="hello@yourprofile.com"
                     value={value}
                     onChangeText={onChange}
                     keyboardType="email-address"
@@ -427,6 +485,7 @@ export function ProfileWizard({
               name="instagram"
               render={({ field: { onChange, value } }) => (
                 <Input
+                  variant="light"
                   label="Instagram handle (optional)"
                   placeholder="yourhandle (without @)"
                   value={value}
@@ -437,14 +496,15 @@ export function ProfileWizard({
               )}
             />
 
-            {/* Booking link */}
+            {/* Booking / registration link */}
             <Controller
               control={control}
               name="bookingLink"
               render={({ field: { onChange, value } }) => (
                 <Input
-                  label="Booking link (optional)"
-                  placeholder="e.g. Calendly, Square, etc."
+                  variant="light"
+                  label={bookingLinkLabel}
+                  placeholder="e.g. Calendly, Eventbrite, form link..."
                   value={value}
                   onChangeText={onChange}
                   autoCapitalize="none"
@@ -460,6 +520,7 @@ export function ProfileWizard({
               name="website"
               render={({ field: { onChange, value } }) => (
                 <Input
+                  variant="light"
                   label="Website (optional)"
                   placeholder="https://yourwebsite.com"
                   value={value}
@@ -477,6 +538,7 @@ export function ProfileWizard({
               name="phone"
               render={({ field: { onChange, value } }) => (
                 <Input
+                  variant="light"
                   label="Phone / WhatsApp (optional)"
                   placeholder="+1 555 000 0000"
                   value={value}
@@ -488,12 +550,12 @@ export function ProfileWizard({
           </View>
         )}
 
-        {/* ── Step 6: Review ────────────────────────────────────────────────── */}
-        {currentStep === 6 && (
+        {/* ── Step 7: Review ────────────────────────────────────────────────── */}
+        {currentStep === 7 && (
           <View>
             <View style={styles.stepHeader}>
               <Text variant="heading2" style={styles.stepTitle}>
-                Review your profile
+                Review your application
               </Text>
               <Text variant="bodySm" style={styles.stepSubtitle}>
                 Once submitted, our team will review your profile before it goes live.
@@ -512,8 +574,8 @@ export function ProfileWizard({
 
             <View style={styles.reviewNote}>
               <Text variant="caption" style={styles.reviewNoteText}>
-                Your profile will be submitted for review. You will be notified once it is approved
-                and visible to the community.
+                Your verified profile application will be manually reviewed by our team. You will be
+                notified once it is approved and visible to the community.
               </Text>
             </View>
           </View>
@@ -556,10 +618,10 @@ const styles = StyleSheet.create({
     gap: spacing[3],
   },
   stepTitle: {
-    color: '#CEC1AE',
+    color: '#2F0A0A',
   },
   stepSubtitle: {
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
   },
 
   // Description textarea
@@ -568,7 +630,7 @@ const styles = StyleSheet.create({
   },
   textareaLabel: {
     marginBottom: spacing[2],
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   textarea: {
     minHeight: 100,
@@ -576,12 +638,12 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     paddingHorizontal: 0,
     fontSize: fontSize.base,
-    color: '#CEC1AE',
+    color: '#1a1212',
     backgroundColor: 'transparent',
     textAlignVertical: 'top',
   },
   textareaDefault: {
-    borderBottomColor: '#7b625b',
+    borderBottomColor: 'rgba(160, 122, 95, 0.30)',
   },
   textareaError: {
     borderBottomColor: colors.error[500],
@@ -596,12 +658,12 @@ const styles = StyleSheet.create({
     color: colors.error[500],
   },
   charCount: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
   },
 
   // Field note
   fieldNote: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
     marginTop: -spacing[4],
     marginBottom: spacing[6],
   },
@@ -612,7 +674,7 @@ const styles = StyleSheet.create({
     gap: spacing[3],
   },
   groupLabel: {
-    color: '#7b625b',
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   chipRow: {
     flexDirection: 'row',
@@ -623,37 +685,37 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[6],
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
     alignItems: 'center',
   },
   priceChipSelected: {
-    borderColor: '#CEC1AE',
-    backgroundColor: colors.burgundy.raised,
+    borderColor: '#2F0A0A',
+    backgroundColor: '#fff9f5',
   },
   priceLabel: {
     fontSize: 14,
     fontWeight: '500',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
   },
   priceLabelSelected: {
-    color: '#CEC1AE',
+    color: '#2F0A0A',
     fontWeight: '700',
   },
 
   // Review card
   previewCard: {
-    backgroundColor: colors.burgundy.surface,
+    backgroundColor: '#ffffff',
     borderRadius: 16,
     padding: spacing[6],
     borderWidth: 1,
-    borderColor: colors.burgundy.raised,
+    borderColor: '#e5e1dc',
   },
   reviewNote: {
     marginTop: spacing[6],
     paddingHorizontal: spacing[2],
   },
   reviewNoteText: {
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.45)',
     textAlign: 'center',
     lineHeight: 18,
   },
@@ -665,13 +727,13 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[4],
     gap: spacing[3],
     borderTopWidth: 1,
-    borderTopColor: colors.burgundy.surface,
+    borderTopColor: '#e5e1dc',
   },
   backBtn: {
     flex: 1,
   },
   nextBtn: {
     flex: 2,
-    backgroundColor: '#CEC1AE',
+    backgroundColor: '#2F0A0A',
   },
 });

--- a/src/features/profile/components/SelectableList.tsx
+++ b/src/features/profile/components/SelectableList.tsx
@@ -1,6 +1,5 @@
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 
 interface SelectableListProps {
@@ -45,25 +44,25 @@ const styles = StyleSheet.create({
     borderColor: 'transparent',
   },
   itemSelected: {
-    backgroundColor: colors.burgundy.raised,
-    borderColor: '#CEC1AE',
+    backgroundColor: '#fff9f5',
+    borderColor: '#2F0A0A',
   },
   dot: {
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: colors.burgundy.mid,
+    backgroundColor: 'rgba(160, 122, 95, 0.30)',
   },
   dotSelected: {
-    backgroundColor: '#CEC1AE',
+    backgroundColor: '#2F0A0A',
   },
   itemLabel: {
     fontSize: 14,
     fontWeight: '400',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
   },
   itemLabelSelected: {
-    color: '#CEC1AE',
+    color: '#1a1212',
     fontWeight: '600',
   },
 });

--- a/src/features/profile/components/ServiceTypeSelector.tsx
+++ b/src/features/profile/components/ServiceTypeSelector.tsx
@@ -1,6 +1,5 @@
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { SERVICE_TYPE_OPTIONS } from '../schemas/professional-profile.schema';
 
@@ -44,19 +43,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[5],
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
   },
   chipSelected: {
-    backgroundColor: colors.burgundy.raised,
-    borderColor: '#CEC1AE',
+    backgroundColor: '#fff9f5',
+    borderColor: '#2F0A0A',
   },
   chipLabel: {
     fontSize: 14,
     fontWeight: '500',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
   },
   chipLabelSelected: {
-    color: '#CEC1AE',
+    color: '#1a1212',
     fontWeight: '600',
   },
 });

--- a/src/features/profile/components/StepIndicator.tsx
+++ b/src/features/profile/components/StepIndicator.tsx
@@ -1,13 +1,13 @@
 import { View, StyleSheet } from 'react-native';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 
 const STEP_LABELS = [
-  'Profile Type',
+  'Identity',
+  'How you operate',
   'Category',
-  'Subcategory',
-  'Service Type',
+  'Specialties',
+  'Delivery',
   'Location',
   'About & Contact',
   'Review',
@@ -53,13 +53,13 @@ const styles = StyleSheet.create({
     borderRadius: 2,
   },
   barActive: {
-    backgroundColor: '#CEC1AE',
+    backgroundColor: '#2F0A0A',
   },
   barInactive: {
-    backgroundColor: colors.burgundy.raised,
+    backgroundColor: '#e5e1dc',
   },
   label: {
-    color: colors.burgundy.muted,
+    color: '#2F0A0A',
     letterSpacing: 0.3,
   },
 });

--- a/src/features/profile/components/SubcategorySelector.tsx
+++ b/src/features/profile/components/SubcategorySelector.tsx
@@ -1,6 +1,5 @@
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Text } from '@components/ui';
-import { colors } from '@theme/colors';
 import { spacing } from '@theme/spacing';
 import { SUBCATEGORIES_BY_CATEGORY } from '../schemas/professional-profile.schema';
 
@@ -55,19 +54,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: colors.burgundy.mid,
+    borderColor: 'rgba(160, 122, 95, 0.30)',
   },
   tagSelected: {
-    backgroundColor: colors.burgundy.raised,
-    borderColor: '#CEC1AE',
+    backgroundColor: '#fff9f5',
+    borderColor: '#2F0A0A',
   },
   tagLabel: {
     fontSize: 13,
     fontWeight: '500',
-    color: colors.burgundy.muted,
+    color: 'rgba(26, 18, 18, 0.55)',
   },
   tagLabelSelected: {
-    color: '#CEC1AE',
+    color: '#1a1212',
     fontWeight: '600',
   },
 });

--- a/src/features/profile/components/__tests__/BusinessTypeSelector.test.tsx
+++ b/src/features/profile/components/__tests__/BusinessTypeSelector.test.tsx
@@ -10,17 +10,17 @@ describe('BusinessTypeSelector', () => {
 
   it('renders all 4 profile type cards', () => {
     const { getByText } = render(<BusinessTypeSelector value={undefined} onChange={jest.fn()} />);
-    expect(getByText('Shop')).toBeTruthy();
-    expect(getByText('Service')).toBeTruthy();
-    expect(getByText('Organizer')).toBeTruthy();
-    expect(getByText('Classes & Circles')).toBeTruthy();
+    expect(getByText('Community organizer')).toBeTruthy();
+    expect(getByText('Mosque / association')).toBeTruthy();
+    expect(getByText('Business / brand')).toBeTruthy();
+    expect(getByText('Freelancer / service provider')).toBeTruthy();
   });
 
   it('calls onChange with the selected type when a card is pressed', () => {
     const onChange = jest.fn();
     const { getByText } = render(<BusinessTypeSelector value={undefined} onChange={onChange} />);
-    fireEvent.press(getByText('Service'));
-    expect(onChange).toHaveBeenCalledWith('service');
+    fireEvent.press(getByText('Freelancer / service provider'));
+    expect(onChange).toHaveBeenCalledWith('freelancer_service');
   });
 
   it('renders an error message when error prop is provided', () => {
@@ -35,8 +35,10 @@ describe('BusinessTypeSelector', () => {
     expect(queryByText('Required')).toBeNull();
   });
 
-  it('renders the "shop" card as selected when value is shop', () => {
-    const { getByText } = render(<BusinessTypeSelector value="shop" onChange={jest.fn()} />);
-    expect(getByText('Shop')).toBeTruthy();
+  it('renders the "community_organizer" card as selected when value is community_organizer', () => {
+    const { getByText } = render(
+      <BusinessTypeSelector value="community_organizer" onChange={jest.fn()} />,
+    );
+    expect(getByText('Community organizer')).toBeTruthy();
   });
 });

--- a/src/features/profile/components/__tests__/CategorySelector.test.tsx
+++ b/src/features/profile/components/__tests__/CategorySelector.test.tsx
@@ -10,17 +10,17 @@ describe('CategorySelector', () => {
     expect(getByText(/Go back and select a profile type first/)).toBeTruthy();
   });
 
-  it('renders categories for the service profile type', () => {
+  it('renders categories for the freelancer_service profile type', () => {
     const { getByText } = render(
-      <CategorySelector profileType="service" value="" onChange={jest.fn()} />,
+      <CategorySelector profileType="freelancer_service" value="" onChange={jest.fn()} />,
     );
     expect(getByText('Beauty')).toBeTruthy();
     expect(getByText('Fitness')).toBeTruthy();
   });
 
-  it('renders categories for the shop profile type', () => {
+  it('renders categories for the business_brand profile type', () => {
     const { getByText } = render(
-      <CategorySelector profileType="shop" value="" onChange={jest.fn()} />,
+      <CategorySelector profileType="business_brand" value="" onChange={jest.fn()} />,
     );
     expect(getByText('Clothing')).toBeTruthy();
     expect(getByText('Food & Sweets')).toBeTruthy();
@@ -29,7 +29,7 @@ describe('CategorySelector', () => {
   it('calls onChange with the selected category when pressed', () => {
     const onChange = jest.fn();
     const { getByText } = render(
-      <CategorySelector profileType="service" value="" onChange={onChange} />,
+      <CategorySelector profileType="freelancer_service" value="" onChange={onChange} />,
     );
     fireEvent.press(getByText('Beauty'));
     expect(onChange).toHaveBeenCalledWith('Beauty');
@@ -38,7 +38,7 @@ describe('CategorySelector', () => {
   it('renders an error message when error prop is provided', () => {
     const { getByText } = render(
       <CategorySelector
-        profileType="service"
+        profileType="freelancer_service"
         value=""
         onChange={jest.fn()}
         error="Please select a category"
@@ -49,7 +49,7 @@ describe('CategorySelector', () => {
 
   it('does not render error text when error is undefined', () => {
     const { queryByText } = render(
-      <CategorySelector profileType="service" value="" onChange={jest.fn()} />,
+      <CategorySelector profileType="freelancer_service" value="" onChange={jest.fn()} />,
     );
     expect(queryByText('Please select a category')).toBeNull();
   });

--- a/src/features/profile/components/__tests__/MonetizationTypeSelector.test.tsx
+++ b/src/features/profile/components/__tests__/MonetizationTypeSelector.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { MonetizationTypeSelector } from '../MonetizationTypeSelector';
+
+describe('MonetizationTypeSelector', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = render(<MonetizationTypeSelector value={undefined} onChange={jest.fn()} />);
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it('renders both monetization type options', () => {
+    const { getByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={jest.fn()} />,
+    );
+    expect(getByText('Nonprofit / community-based')).toBeTruthy();
+    expect(getByText('For-profit / paid')).toBeTruthy();
+  });
+
+  it('calls onChange with nonprofit when that card is pressed', () => {
+    const onChange = jest.fn();
+    const { getByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={onChange} />,
+    );
+    fireEvent.press(getByText('Nonprofit / community-based'));
+    expect(onChange).toHaveBeenCalledWith('nonprofit');
+  });
+
+  it('calls onChange with for_profit when that card is pressed', () => {
+    const onChange = jest.fn();
+    const { getByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={onChange} />,
+    );
+    fireEvent.press(getByText('For-profit / paid'));
+    expect(onChange).toHaveBeenCalledWith('for_profit');
+  });
+
+  it('renders an error message when error prop is provided', () => {
+    const { getByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={jest.fn()} error="Required" />,
+    );
+    expect(getByText('Required')).toBeTruthy();
+  });
+
+  it('does not render error text when error is undefined', () => {
+    const { queryByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={jest.fn()} />,
+    );
+    expect(queryByText('Required')).toBeNull();
+  });
+
+  it('renders descriptions for each option', () => {
+    const { getByText } = render(
+      <MonetizationTypeSelector value={undefined} onChange={jest.fn()} />,
+    );
+    expect(getByText('Free or donation-based, no profit goal')).toBeTruthy();
+    expect(getByText('Charge for products or services')).toBeTruthy();
+  });
+});

--- a/src/features/profile/components/__tests__/ProfilePreviewCard.test.tsx
+++ b/src/features/profile/components/__tests__/ProfilePreviewCard.test.tsx
@@ -5,10 +5,11 @@ import type { ProfessionalProfileFormData } from '../../schemas/professional-pro
 
 const baseData: ProfessionalProfileFormData = {
   businessName: 'Henna by Fatima',
-  profileType: 'service',
+  profileType: 'freelancer_service',
+  monetizationType: 'for_profit',
   category: 'Beauty',
   subcategories: ['Henna', 'Makeup'],
-  serviceTypes: ['at_home', 'travels_to_client'],
+  serviceTypes: ['in_person', 'travels_to_client'],
   basedIn: 'Montreal',
   servesAreas: ['Laval'],
   description: 'Specialised henna artist serving the Montreal community.',
@@ -34,7 +35,7 @@ describe('ProfilePreviewCard', () => {
 
   it('displays the profile type label', () => {
     const { getAllByText } = render(<ProfilePreviewCard data={baseData} onEditStep={jest.fn()} />);
-    expect(getAllByText('Service').length).toBeGreaterThan(0);
+    expect(getAllByText('Freelancer / service provider').length).toBeGreaterThan(0);
   });
 
   it('displays the category', () => {
@@ -50,7 +51,7 @@ describe('ProfilePreviewCard', () => {
 
   it('displays service type labels', () => {
     const { getByText } = render(<ProfilePreviewCard data={baseData} onEditStep={jest.fn()} />);
-    expect(getByText('At home')).toBeTruthy();
+    expect(getByText('In person')).toBeTruthy();
     expect(getByText('Travels to client')).toBeTruthy();
   });
 
@@ -74,13 +75,13 @@ describe('ProfilePreviewCard', () => {
     expect(getByText('hello@henna.com')).toBeTruthy();
   });
 
-  it('calls onEditStep with step 1 when Category Edit is pressed', () => {
+  it('calls onEditStep with step 2 when Category Edit is pressed', () => {
     const onEditStep = jest.fn();
     const { getAllByText } = render(<ProfilePreviewCard data={baseData} onEditStep={onEditStep} />);
     const editButtons = getAllByText('Edit');
-    // Category section is the second Edit button (after Profile Type)
-    fireEvent.press(editButtons[1]);
-    expect(onEditStep).toHaveBeenCalledWith(1);
+    // Order: Profile type (0→step0), How you operate (1→step1), Category (2→step2)
+    fireEvent.press(editButtons[2]);
+    expect(onEditStep).toHaveBeenCalledWith(2);
   });
 
   it('shows empty state when category is not set', () => {
@@ -104,6 +105,6 @@ describe('ProfilePreviewCard', () => {
     const { queryByText } = render(
       <ProfilePreviewCard data={{ ...baseData, serviceTypes: [] }} onEditStep={jest.fn()} />,
     );
-    expect(queryByText('Service Type')).toBeNull();
+    expect(queryByText('Delivery')).toBeNull();
   });
 });

--- a/src/features/profile/components/__tests__/ProfileWizard.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileWizard.test.tsx
@@ -32,8 +32,18 @@ jest.mock('../BusinessTypeSelector', () => {
   const { Text } = require('react-native');
   return {
     BusinessTypeSelector: ({ onChange }: { onChange: (v: string) => void }) => (
-      <Text testID="type-selector" onPress={() => onChange('service')}>
+      <Text testID="type-selector" onPress={() => onChange('freelancer_service')}>
         select-type
+      </Text>
+    ),
+  };
+});
+jest.mock('../MonetizationTypeSelector', () => {
+  const { Text } = require('react-native');
+  return {
+    MonetizationTypeSelector: ({ onChange }: { onChange: (v: string) => void }) => (
+      <Text testID="monetization-selector" onPress={() => onChange('for_profit')}>
+        select-monetization
       </Text>
     ),
   };
@@ -62,7 +72,7 @@ jest.mock('../ServiceTypeSelector', () => {
   const { Text } = require('react-native');
   return {
     ServiceTypeSelector: ({ onChange }: { onChange: (v: string[]) => void }) => (
-      <Text testID="service-type-selector" onPress={() => onChange(['at_home'])}>
+      <Text testID="service-type-selector" onPress={() => onChange(['in_person'])}>
         select-service-type
       </Text>
     ),
@@ -104,9 +114,12 @@ jest.mock('../ProfilePreviewCard', () => {
 
 const mockOnSubmit = jest.fn().mockResolvedValue(undefined);
 
+// business_brand skips subcategory (step 3) and service type (step 4)
+// path: 0 → 1 → 2 → 5 → 6 → 7 (5 Next presses to reach review)
 const fullDefaultValues = {
   businessName: 'Test Business',
-  profileType: 'shop' as const,
+  profileType: 'business_brand' as const,
+  monetizationType: 'for_profit' as const,
   category: 'Food & Sweets',
   subcategories: [],
   serviceTypes: [],
@@ -163,31 +176,47 @@ describe('ProfileWizard', () => {
     expect(getByDisplayValue('My Business')).toBeTruthy();
   });
 
-  it('skips subcategory step (step 2) for non-service profile types', async () => {
+  it('skips subcategory and service type steps for non-freelancer_service profile types', async () => {
     const { getByText, getByTestId } = render(
       <ProfileWizard
         submitLabel="Submit"
         onSubmit={mockOnSubmit}
-        defaultValues={{ businessName: 'Test', profileType: 'shop', category: 'Food & Sweets' }}
+        defaultValues={{
+          businessName: 'Test',
+          profileType: 'business_brand',
+          monetizationType: 'for_profit',
+          category: 'Food & Sweets',
+        }}
       />,
     );
     await act(async () => fireEvent.press(getByText('Next')));
     expect(getByTestId('step-indicator').props.children).toBe('step-1');
     await act(async () => fireEvent.press(getByText('Next')));
-    expect(getByTestId('step-indicator').props.children).toBe('step-3');
+    expect(getByTestId('step-indicator').props.children).toBe('step-2');
+    await act(async () => fireEvent.press(getByText('Next')));
+    // Skips step 3 (subcategory) and step 4 (service type) → lands on step 5
+    expect(getByTestId('step-indicator').props.children).toBe('step-5');
   });
 
-  it('goes to step 2 (subcategory) for service profile type', async () => {
+  it('goes to step 3 (subcategory) for freelancer_service profile type', async () => {
     const { getByText, getByTestId } = render(
       <ProfileWizard
         submitLabel="Submit"
         onSubmit={mockOnSubmit}
-        defaultValues={{ businessName: 'Test', profileType: 'service', category: 'Beauty' }}
+        defaultValues={{
+          businessName: 'Test',
+          profileType: 'freelancer_service',
+          monetizationType: 'for_profit',
+          category: 'Beauty',
+        }}
       />,
     );
     await act(async () => fireEvent.press(getByText('Next')));
+    expect(getByTestId('step-indicator').props.children).toBe('step-1');
     await act(async () => fireEvent.press(getByText('Next')));
     expect(getByTestId('step-indicator').props.children).toBe('step-2');
+    await act(async () => fireEvent.press(getByText('Next')));
+    expect(getByTestId('step-indicator').props.children).toBe('step-3');
   });
 
   it('Back from step 1 returns to step 0', async () => {
@@ -195,7 +224,12 @@ describe('ProfileWizard', () => {
       <ProfileWizard
         submitLabel="Submit"
         onSubmit={mockOnSubmit}
-        defaultValues={{ businessName: 'Test', profileType: 'shop', category: 'Food & Sweets' }}
+        defaultValues={{
+          businessName: 'Test',
+          profileType: 'business_brand',
+          monetizationType: 'for_profit',
+          category: 'Food & Sweets',
+        }}
       />,
     );
     await act(async () => fireEvent.press(getByText('Next')));
@@ -204,35 +238,47 @@ describe('ProfileWizard', () => {
     expect(getByTestId('step-indicator').props.children).toBe('step-0');
   });
 
-  it('Back from step 3 goes to step 1 for non-service type (skips subcategory)', async () => {
+  it('Back from step 5 goes to step 2 for non-freelancer_service type (skips steps 3 and 4)', async () => {
     const { getByText, getByTestId } = render(
       <ProfileWizard
         submitLabel="Submit"
         onSubmit={mockOnSubmit}
-        defaultValues={{ businessName: 'Test', profileType: 'shop', category: 'Food & Sweets' }}
-      />,
-    );
-    await act(async () => fireEvent.press(getByText('Next')));
-    await act(async () => fireEvent.press(getByText('Next')));
-    expect(getByTestId('step-indicator').props.children).toBe('step-3');
-    fireEvent.press(getByText('Back'));
-    expect(getByTestId('step-indicator').props.children).toBe('step-1');
-  });
-
-  it('Back from step 3 goes to step 2 for service type', async () => {
-    const { getByText, getByTestId } = render(
-      <ProfileWizard
-        submitLabel="Submit"
-        onSubmit={mockOnSubmit}
-        defaultValues={{ businessName: 'Test', profileType: 'service', category: 'Beauty' }}
+        defaultValues={{
+          businessName: 'Test',
+          profileType: 'business_brand',
+          monetizationType: 'for_profit',
+          category: 'Food & Sweets',
+        }}
       />,
     );
     await act(async () => fireEvent.press(getByText('Next')));
     await act(async () => fireEvent.press(getByText('Next')));
     await act(async () => fireEvent.press(getByText('Next')));
-    expect(getByTestId('step-indicator').props.children).toBe('step-3');
+    expect(getByTestId('step-indicator').props.children).toBe('step-5');
     fireEvent.press(getByText('Back'));
     expect(getByTestId('step-indicator').props.children).toBe('step-2');
+  });
+
+  it('Back from step 4 goes to step 3 for freelancer_service type', async () => {
+    const { getByText, getByTestId } = render(
+      <ProfileWizard
+        submitLabel="Submit"
+        onSubmit={mockOnSubmit}
+        defaultValues={{
+          businessName: 'Test',
+          profileType: 'freelancer_service',
+          monetizationType: 'for_profit',
+          category: 'Beauty',
+        }}
+      />,
+    );
+    await act(async () => fireEvent.press(getByText('Next')));
+    await act(async () => fireEvent.press(getByText('Next')));
+    await act(async () => fireEvent.press(getByText('Next')));
+    await act(async () => fireEvent.press(getByText('Next')));
+    expect(getByTestId('step-indicator').props.children).toBe('step-4');
+    fireEvent.press(getByText('Back'));
+    expect(getByTestId('step-indicator').props.children).toBe('step-3');
   });
 
   it('shows the submitLabel on the last step', async () => {
@@ -243,6 +289,7 @@ describe('ProfileWizard', () => {
         defaultValues={fullDefaultValues}
       />,
     );
+    // business_brand path: 0→1→2→5→6→7 (5 presses)
     for (let i = 0; i < 5; i++) {
       await act(async () => fireEvent.press(getByText('Next')));
     }
@@ -267,14 +314,15 @@ describe('ProfileWizard', () => {
     );
   });
 
-  it('resets subcategories when category changes on step 1', async () => {
+  it('resets subcategories when category changes on step 2', async () => {
     const { getByText, getByTestId } = render(
       <ProfileWizard
         submitLabel="Submit"
         onSubmit={mockOnSubmit}
         defaultValues={{
           businessName: 'Test',
-          profileType: 'service',
+          profileType: 'freelancer_service',
+          monetizationType: 'for_profit',
           category: 'Beauty',
           subcategories: ['Henna'],
         }}
@@ -282,11 +330,13 @@ describe('ProfileWizard', () => {
     );
     await act(async () => fireEvent.press(getByText('Next')));
     expect(getByTestId('step-indicator').props.children).toBe('step-1');
+    await act(async () => fireEvent.press(getByText('Next')));
+    expect(getByTestId('step-indicator').props.children).toBe('step-2');
     // Trigger category change — mock calls onChange('Beauty'), which resets subcategories
     fireEvent.press(getByTestId('category-selector'));
     // Advance to subcategory step and check subcategories were reset
     await act(async () => fireEvent.press(getByText('Next')));
-    expect(getByTestId('step-indicator').props.children).toBe('step-2');
+    expect(getByTestId('step-indicator').props.children).toBe('step-3');
   });
 
   it('onEditStep from preview card navigates back to the given step', async () => {
@@ -297,15 +347,16 @@ describe('ProfileWizard', () => {
         defaultValues={fullDefaultValues}
       />,
     );
+    // business_brand path: 0→1→2→5→6→7 (5 presses)
     for (let i = 0; i < 5; i++) {
       await act(async () => fireEvent.press(getByText('Next')));
     }
-    expect(getByTestId('step-indicator').props.children).toBe('step-6');
+    expect(getByTestId('step-indicator').props.children).toBe('step-7');
     fireEvent.press(getByTestId('preview-card'));
     expect(getByTestId('step-indicator').props.children).toBe('step-0');
   });
 
-  it('shows the price chip toggle on step 5', async () => {
+  it('shows the price chip toggle on step 6 (About & Contact)', async () => {
     const { getByText, getByTestId } = render(
       <ProfileWizard
         submitLabel="Submit"
@@ -313,11 +364,11 @@ describe('ProfileWizard', () => {
         defaultValues={fullDefaultValues}
       />,
     );
-    // Navigate to step 5: 0→1→3→4→5
+    // Navigate to step 6: 0→1→2→5→6 (4 presses for business_brand)
     for (let i = 0; i < 4; i++) {
       await act(async () => fireEvent.press(getByText('Next')));
     }
-    expect(getByTestId('step-indicator').props.children).toBe('step-5');
+    expect(getByTestId('step-indicator').props.children).toBe('step-6');
     // Select a price range chip
     fireEvent.press(getByText('$'));
     // Press it again to deselect (covers the isSelected ? undefined : range branch)

--- a/src/features/profile/components/__tests__/ServiceTypeSelector.test.tsx
+++ b/src/features/profile/components/__tests__/ServiceTypeSelector.test.tsx
@@ -10,9 +10,9 @@ describe('ServiceTypeSelector', () => {
 
   it('renders all 4 service type options', () => {
     const { getByText } = render(<ServiceTypeSelector value={[]} onChange={jest.fn()} />);
-    expect(getByText('At home')).toBeTruthy();
-    expect(getByText('Has a studio')).toBeTruthy();
+    expect(getByText('In person')).toBeTruthy();
     expect(getByText('Online')).toBeTruthy();
+    expect(getByText('Hybrid')).toBeTruthy();
     expect(getByText('Travels to client')).toBeTruthy();
   });
 
@@ -32,8 +32,8 @@ describe('ServiceTypeSelector', () => {
 
   it('preserves existing selections when adding a new one', () => {
     const onChange = jest.fn();
-    const { getByText } = render(<ServiceTypeSelector value={['at_home']} onChange={onChange} />);
+    const { getByText } = render(<ServiceTypeSelector value={['in_person']} onChange={onChange} />);
     fireEvent.press(getByText('Online'));
-    expect(onChange).toHaveBeenCalledWith(['at_home', 'online']);
+    expect(onChange).toHaveBeenCalledWith(['in_person', 'online']);
   });
 });

--- a/src/features/profile/components/__tests__/StepIndicator.test.tsx
+++ b/src/features/profile/components/__tests__/StepIndicator.test.tsx
@@ -4,27 +4,27 @@ import { StepIndicator } from '../StepIndicator';
 
 describe('StepIndicator', () => {
   it('renders without crashing', () => {
-    const { toJSON } = render(<StepIndicator currentStep={0} totalSteps={7} />);
+    const { toJSON } = render(<StepIndicator currentStep={0} totalSteps={8} />);
     expect(toJSON()).not.toBeNull();
   });
 
   it('displays the correct step label for step 0', () => {
-    const { getByText } = render(<StepIndicator currentStep={0} totalSteps={7} />);
-    expect(getByText(/Profile Type/)).toBeTruthy();
+    const { getByText } = render(<StepIndicator currentStep={0} totalSteps={8} />);
+    expect(getByText(/Identity/)).toBeTruthy();
   });
 
   it('displays the correct step label for step 1', () => {
-    const { getByText } = render(<StepIndicator currentStep={1} totalSteps={7} />);
-    expect(getByText(/Category/)).toBeTruthy();
+    const { getByText } = render(<StepIndicator currentStep={1} totalSteps={8} />);
+    expect(getByText(/How you operate/)).toBeTruthy();
   });
 
   it('displays the current step number and total', () => {
-    const { getByText } = render(<StepIndicator currentStep={2} totalSteps={7} />);
-    expect(getByText(/3 of 7/)).toBeTruthy();
+    const { getByText } = render(<StepIndicator currentStep={2} totalSteps={8} />);
+    expect(getByText(/3 of 8/)).toBeTruthy();
   });
 
   it('shows the last step label correctly', () => {
-    const { getByText } = render(<StepIndicator currentStep={6} totalSteps={7} />);
+    const { getByText } = render(<StepIndicator currentStep={7} totalSteps={8} />);
     expect(getByText(/Review/)).toBeTruthy();
   });
 

--- a/src/features/profile/schemas/__tests__/professional-profile.schema.test.ts
+++ b/src/features/profile/schemas/__tests__/professional-profile.schema.test.ts
@@ -1,6 +1,7 @@
 import {
   professionalProfileSchema,
   PROFILE_TYPES,
+  MONETIZATION_TYPES,
   CATEGORIES_BY_TYPE,
   SUBCATEGORIES_BY_CATEGORY,
   SERVICE_TYPE_OPTIONS,
@@ -14,10 +15,11 @@ import {
 
 const validBase = {
   businessName: 'Henna by Fatima',
-  profileType: 'service' as const,
+  profileType: 'freelancer_service' as const,
+  monetizationType: 'for_profit' as const,
   category: 'Beauty',
   subcategories: ['Henna', 'Makeup'],
-  serviceTypes: ['at_home', 'travels_to_client'],
+  serviceTypes: ['in_person', 'travels_to_client'],
   basedIn: 'Montreal',
   servesAreas: ['Laval', 'Longueuil'],
   description: 'Specialised henna artist serving the Montreal community.',
@@ -52,6 +54,21 @@ describe('professionalProfileSchema', () => {
   it('accepts all valid profile types', () => {
     for (const { value } of PROFILE_TYPES) {
       const result = professionalProfileSchema.safeParse({ ...validBase, profileType: value });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects an invalid monetizationType', () => {
+    const result = professionalProfileSchema.safeParse({
+      ...validBase,
+      monetizationType: 'mixed',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all valid monetization types', () => {
+    for (const { value } of MONETIZATION_TYPES) {
+      const result = professionalProfileSchema.safeParse({ ...validBase, monetizationType: value });
       expect(result.success).toBe(true);
     }
   });
@@ -103,12 +120,12 @@ describe('PROFILE_TYPES', () => {
     expect(PROFILE_TYPES).toHaveLength(4);
   });
 
-  it('includes shop, service, organizer, classes_circles', () => {
+  it('includes the 4 verified profile identity types', () => {
     const values = PROFILE_TYPES.map((t) => t.value);
-    expect(values).toContain('shop');
-    expect(values).toContain('service');
-    expect(values).toContain('organizer');
-    expect(values).toContain('classes_circles');
+    expect(values).toContain('community_organizer');
+    expect(values).toContain('nonprofit_organization');
+    expect(values).toContain('business_brand');
+    expect(values).toContain('freelancer_service');
   });
 
   it('each type has a label and description', () => {
@@ -119,12 +136,31 @@ describe('PROFILE_TYPES', () => {
   });
 });
 
+describe('MONETIZATION_TYPES', () => {
+  it('contains exactly 2 options', () => {
+    expect(MONETIZATION_TYPES).toHaveLength(2);
+  });
+
+  it('includes nonprofit and for_profit', () => {
+    const values = MONETIZATION_TYPES.map((t) => t.value);
+    expect(values).toContain('nonprofit');
+    expect(values).toContain('for_profit');
+  });
+
+  it('each option has a label and description', () => {
+    for (const type of MONETIZATION_TYPES) {
+      expect(type.label.length).toBeGreaterThan(0);
+      expect(type.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe('CATEGORIES_BY_TYPE', () => {
   it('has categories for all 4 profile types', () => {
-    expect(CATEGORIES_BY_TYPE.shop.length).toBeGreaterThan(0);
-    expect(CATEGORIES_BY_TYPE.service.length).toBeGreaterThan(0);
-    expect(CATEGORIES_BY_TYPE.organizer.length).toBeGreaterThan(0);
-    expect(CATEGORIES_BY_TYPE.classes_circles.length).toBeGreaterThan(0);
+    expect(CATEGORIES_BY_TYPE.community_organizer.length).toBeGreaterThan(0);
+    expect(CATEGORIES_BY_TYPE.nonprofit_organization.length).toBeGreaterThan(0);
+    expect(CATEGORIES_BY_TYPE.business_brand.length).toBeGreaterThan(0);
+    expect(CATEGORIES_BY_TYPE.freelancer_service.length).toBeGreaterThan(0);
   });
 });
 
@@ -141,6 +177,14 @@ describe('SUBCATEGORIES_BY_CATEGORY', () => {
 describe('SERVICE_TYPE_OPTIONS', () => {
   it('contains 4 options', () => {
     expect(SERVICE_TYPE_OPTIONS).toHaveLength(4);
+  });
+
+  it('includes in_person, online, hybrid, travels_to_client', () => {
+    const values = SERVICE_TYPE_OPTIONS.map((o) => o.value);
+    expect(values).toContain('in_person');
+    expect(values).toContain('online');
+    expect(values).toContain('hybrid');
+    expect(values).toContain('travels_to_client');
   });
 
   it('each option has value and label', () => {
@@ -171,7 +215,12 @@ describe('PRICE_RANGES', () => {
 
 describe('CATEGORY_STEP_COPY', () => {
   it('has copy for all profile types', () => {
-    const types = ['shop', 'service', 'organizer', 'classes_circles'] as const;
+    const types = [
+      'community_organizer',
+      'nonprofit_organization',
+      'business_brand',
+      'freelancer_service',
+    ] as const;
     for (const type of types) {
       expect(CATEGORY_STEP_COPY[type].title.length).toBeGreaterThan(0);
       expect(CATEGORY_STEP_COPY[type].subtitle.length).toBeGreaterThan(0);
@@ -180,8 +229,8 @@ describe('CATEGORY_STEP_COPY', () => {
 });
 
 describe('STEP_FIELDS', () => {
-  it('has 7 entries for 7 steps', () => {
-    expect(STEP_FIELDS).toHaveLength(7);
+  it('has 8 entries for 8 steps', () => {
+    expect(STEP_FIELDS).toHaveLength(8);
   });
 
   it('step 0 validates businessName and profileType', () => {
@@ -189,12 +238,16 @@ describe('STEP_FIELDS', () => {
     expect(STEP_FIELDS[0]).toContain('profileType');
   });
 
-  it('step 1 validates category', () => {
-    expect(STEP_FIELDS[1]).toContain('category');
+  it('step 1 validates monetizationType', () => {
+    expect(STEP_FIELDS[1]).toContain('monetizationType');
   });
 
-  it('step 4 validates basedIn', () => {
-    expect(STEP_FIELDS[4]).toContain('basedIn');
+  it('step 2 validates category', () => {
+    expect(STEP_FIELDS[2]).toContain('category');
+  });
+
+  it('step 5 validates basedIn', () => {
+    expect(STEP_FIELDS[5]).toContain('basedIn');
   });
 });
 
@@ -205,5 +258,6 @@ describe('PROFILE_STATUS', () => {
     expect(PROFILE_STATUS.APPROVED).toBe('approved');
     expect(PROFILE_STATUS.CHANGES_REQUESTED).toBe('changes_requested');
     expect(PROFILE_STATUS.REJECTED).toBe('rejected');
+    expect(PROFILE_STATUS.NEEDS_FOLLOW_UP).toBe('needs_follow_up');
   });
 });

--- a/src/features/profile/schemas/professional-profile.schema.ts
+++ b/src/features/profile/schemas/professional-profile.schema.ts
@@ -1,54 +1,98 @@
 import { z } from 'zod';
 
-// ── Profile types ─────────────────────────────────────────────────────────────
+// ── Profile identity types ─────────────────────────────────────────────────────
 
 export const PROFILE_TYPES = [
-  { value: 'shop' as const, label: 'Shop', description: 'Sell physical products' },
-  { value: 'service' as const, label: 'Service', description: 'Offer a service' },
   {
-    value: 'organizer' as const,
-    label: 'Organizer',
-    description: 'Organize events & gatherings',
+    value: 'community_organizer' as const,
+    label: 'Community organizer',
+    description: 'Events, gatherings & community initiatives',
   },
   {
-    value: 'classes_circles' as const,
-    label: 'Classes & Circles',
-    description: 'Run classes, halaqas, or workshops',
+    value: 'nonprofit_organization' as const,
+    label: 'Mosque / association',
+    description: 'Mosques, associations & community organizations',
+  },
+  {
+    value: 'business_brand' as const,
+    label: 'Business / brand',
+    description: 'Products, shops & brands',
+  },
+  {
+    value: 'freelancer_service' as const,
+    label: 'Freelancer / service provider',
+    description: 'Beauty, fitness, photography & more',
   },
 ];
 
-export type ProfileType = 'shop' | 'service' | 'organizer' | 'classes_circles';
+export type ProfileType =
+  | 'community_organizer'
+  | 'nonprofit_organization'
+  | 'business_brand'
+  | 'freelancer_service';
+
+// ── Monetization types ────────────────────────────────────────────────────────
+
+export const MONETIZATION_TYPES = [
+  {
+    value: 'nonprofit' as const,
+    label: 'Nonprofit / community-based',
+    description: 'Free or donation-based, no profit goal',
+  },
+  {
+    value: 'for_profit' as const,
+    label: 'For-profit / paid',
+    description: 'Charge for products or services',
+  },
+];
+
+export type MonetizationType = 'nonprofit' | 'for_profit';
 
 // ── Categories per profile type ───────────────────────────────────────────────
 
 export const CATEGORIES_BY_TYPE: Record<ProfileType, string[]> = {
-  shop: [
+  community_organizer: [
+    'Eid Events',
+    'Bazaars',
+    'Sisters Events',
+    'Community Events',
+    'Workshops',
+    'Cultural Events',
+  ],
+  nonprofit_organization: [
+    'Mosque / Masjid',
+    'Association',
+    'Community Group',
+    'Charity / Foundation',
+    'Educational Institution',
+    'Cultural Centre',
+  ],
+  business_brand: [
     'Clothing',
     'Jewelry & Accessories',
     'Beauty Products',
     'Home & Decor',
     'Food & Sweets',
     'Islamic Products',
-    'Handmade',
+    'Handmade / Artisan',
   ],
-  service: ['Beauty', 'Fitness', 'Photography', 'Event Services', 'Food Services'],
-  organizer: ['Eid Events', 'Bazaars', 'Sisters Events', 'Workshops', 'Community Events'],
-  classes_circles: [
-    'Quran',
-    'Islamic Studies',
-    'Halaqa',
-    'Workshops',
-    'Book Club',
-    'Skill Classes',
+  freelancer_service: [
+    'Beauty',
+    'Fitness',
+    'Photography & Content',
+    'Event Services',
+    'Food Services',
+    'Education & Tutoring',
+    'Design & Creative',
   ],
 };
 
-// ── Subcategories (service providers only) ────────────────────────────────────
+// ── Subcategories (freelancer_service only) ───────────────────────────────────
 
 export const SUBCATEGORIES_BY_CATEGORY: Partial<Record<string, string[]>> = {
   Beauty: ['Henna', 'Makeup', 'Hair', 'Nails', 'Lashes / Brows', 'Facials', 'Massage', 'Laser'],
   Fitness: ['Pilates / Yoga', 'Personal Training', 'Women Fitness Classes', 'Hijama'],
-  Photography: ['Photography', 'Videography', 'Content Creation', 'Graphic Design'],
+  'Photography & Content': ['Photography', 'Videography', 'Content Creation', 'Graphic Design'],
   'Event Services': [
     'Decor & Setup',
     'Catering',
@@ -58,18 +102,25 @@ export const SUBCATEGORIES_BY_CATEGORY: Partial<Record<string, string[]>> = {
     'Equipment Rental',
   ],
   'Food Services': ['Catering', 'Meal Prep', 'Custom Desserts'],
+  'Education & Tutoring': [
+    'Quran Tutoring',
+    'Academic Tutoring',
+    'Language Classes',
+    'Islamic Studies',
+  ],
+  'Design & Creative': ['Graphic Design', 'Web Design', 'Calligraphy', 'Illustration'],
 };
 
-// ── Service types ─────────────────────────────────────────────────────────────
+// ── Service types (how you work) ──────────────────────────────────────────────
 
 export const SERVICE_TYPE_OPTIONS = [
-  { value: 'at_home' as const, label: 'At home' },
-  { value: 'has_studio' as const, label: 'Has a studio' },
+  { value: 'in_person' as const, label: 'In person' },
   { value: 'online' as const, label: 'Online' },
+  { value: 'hybrid' as const, label: 'Hybrid' },
   { value: 'travels_to_client' as const, label: 'Travels to client' },
 ];
 
-export type ServiceTypeValue = 'at_home' | 'has_studio' | 'online' | 'travels_to_client';
+export type ServiceTypeValue = 'in_person' | 'online' | 'hybrid' | 'travels_to_client';
 
 // ── Location options ──────────────────────────────────────────────────────────
 
@@ -85,7 +136,12 @@ export const QC_AREAS = [
 
 export const BASED_IN_OPTIONS = [...QC_AREAS, 'Online only'];
 
-export const SERVES_AREAS_OPTIONS = [...QC_AREAS, 'Online', "At client's home", 'At my location'];
+export const SERVES_AREAS_OPTIONS = [
+  ...QC_AREAS,
+  'Online',
+  "At client's location",
+  'At my location',
+];
 
 // ── Price ranges ──────────────────────────────────────────────────────────────
 
@@ -102,53 +158,73 @@ export const PROFILE_STATUS = {
   APPROVED: 'approved',
   CHANGES_REQUESTED: 'changes_requested',
   REJECTED: 'rejected',
+  NEEDS_FOLLOW_UP: 'needs_follow_up',
 } as const;
 
 export type ProfileStatus = (typeof PROFILE_STATUS)[keyof typeof PROFILE_STATUS];
 
-// ── Step 2 copy (category step) per profile type ──────────────────────────────
+// ── Step 3 copy (category step) per profile type ──────────────────────────────
 
 export const CATEGORY_STEP_COPY: Record<ProfileType, { title: string; subtitle: string }> = {
-  shop: {
-    title: 'What do you sell?',
-    subtitle: 'Select the main category for your shop.',
+  community_organizer: {
+    title: 'What do you organize?',
+    subtitle: 'Select the type of events or gatherings you run.',
   },
-  service: {
+  nonprofit_organization: {
+    title: 'What does your organization focus on?',
+    subtitle: 'Select your main community area.',
+  },
+  business_brand: {
+    title: 'What do you sell?',
+    subtitle: 'Select the main category for your business.',
+  },
+  freelancer_service: {
     title: 'What service do you offer?',
     subtitle: 'Select your main service category.',
   },
-  organizer: {
-    title: 'What do you organize?',
-    subtitle: 'Select the type of events you run.',
-  },
-  classes_circles: {
-    title: 'What do you teach or lead?',
-    subtitle: 'Select your main program type.',
+};
+
+// ── Step 5 copy (service type / delivery mode) per profile type ───────────────
+
+export const SERVICE_TYPE_STEP_COPY: Partial<
+  Record<ProfileType, { title: string; subtitle: string }>
+> = {
+  freelancer_service: {
+    title: 'How do you work?',
+    subtitle: 'Select all that apply. Helps people know how to book you.',
   },
 };
 
 // ── Zod schema ────────────────────────────────────────────────────────────────
 
 export const professionalProfileSchema = z.object({
-  // Step 1 — Profile Type
+  // Step 1 — Identity
   logoUri: z.string().optional(),
   businessName: z.string().min(2, 'A profile name is required'),
-  profileType: z.enum(['shop', 'service', 'organizer', 'classes_circles']),
+  profileType: z.enum([
+    'community_organizer',
+    'nonprofit_organization',
+    'business_brand',
+    'freelancer_service',
+  ]),
 
-  // Step 2 — Category (single-select, required)
+  // Step 2 — Monetization
+  monetizationType: z.enum(['nonprofit', 'for_profit']),
+
+  // Step 3 — Category (single-select, required)
   category: z.string().min(1, 'Please select a category'),
 
-  // Step 3 — Subcategories (multi-select, service only, optional)
+  // Step 4 — Subcategories (multi-select, freelancer_service only, optional)
   subcategories: z.array(z.string()),
 
-  // Step 4 — Service type (multi-select, optional)
+  // Step 5 — Service type / delivery mode (multi-select, optional)
   serviceTypes: z.array(z.string()),
 
-  // Step 5 — Location
+  // Step 6 — Location
   basedIn: z.string().min(1, 'Please select where you are based'),
   servesAreas: z.array(z.string()),
 
-  // Step 6 — About & Contact
+  // Step 7 — About & Contact
   description: z.string().min(10, 'Please add a short description').max(300, 'Max 300 characters'),
   instagram: z.string().optional(),
   phone: z.string().optional(),
@@ -164,11 +240,12 @@ export type ProfessionalProfileFormData = z.infer<typeof professionalProfileSche
 // ── Step-level field maps ─────────────────────────────────────────────────────
 
 export const STEP_FIELDS: (keyof ProfessionalProfileFormData)[][] = [
-  ['businessName', 'profileType'], // 0 — Profile Type
-  ['category'], // 1 — Category
-  [], // 2 — Subcategory (optional)
-  [], // 3 — Service Type (optional)
-  ['basedIn'], // 4 — Location
-  ['description', 'inquiryEmail'], // 5 — About & Contact
-  [], // 6 — Review
+  ['businessName', 'profileType'], // 0 — Identity
+  ['monetizationType'], // 1 — Monetization
+  ['category'], // 2 — Category
+  [], // 3 — Subcategory (freelancer_service only)
+  [], // 4 — Delivery mode (freelancer_service + class_workshop_host)
+  ['basedIn'], // 5 — Location
+  ['description', 'inquiryEmail'], // 6 — About & Contact
+  [], // 7 — Review
 ];

--- a/src/features/profile/utils/__tests__/professional-profile.utils.test.ts
+++ b/src/features/profile/utils/__tests__/professional-profile.utils.test.ts
@@ -3,10 +3,11 @@ import type { ProfessionalProfileFormData } from '@features/profile/schemas/prof
 
 const base: ProfessionalProfileFormData = {
   businessName: 'Henna by Fatima',
-  profileType: 'service',
+  profileType: 'freelancer_service',
+  monetizationType: 'for_profit',
   category: 'Beauty',
   subcategories: ['Henna'],
-  serviceTypes: ['at_home'],
+  serviceTypes: ['in_person'],
   basedIn: 'Montreal',
   servesAreas: ['Montreal'],
   description: 'A great henna artist.',
@@ -22,10 +23,11 @@ describe('formDataToRow', () => {
   it('maps all required fields correctly', () => {
     const row = formDataToRow(base);
     expect(row.business_name).toBe('Henna by Fatima');
-    expect(row.profile_type).toBe('service');
+    expect(row.profile_type).toBe('freelancer_service');
+    expect(row.monetization_type).toBe('for_profit');
     expect(row.category).toBe('Beauty');
     expect(row.subcategories).toEqual(['Henna']);
-    expect(row.service_types).toEqual(['at_home']);
+    expect(row.service_types).toEqual(['in_person']);
     expect(row.based_in).toBe('Montreal');
     expect(row.serves_areas).toEqual(['Montreal']);
     expect(row.description).toBe('A great henna artist.');

--- a/src/features/profile/utils/professional-profile.utils.ts
+++ b/src/features/profile/utils/professional-profile.utils.ts
@@ -8,6 +8,7 @@ export function formDataToRow(data: ProfessionalProfileFormData) {
   return {
     business_name: data.businessName,
     profile_type: data.profileType,
+    monetization_type: data.monetizationType,
     category: data.category,
     subcategories: data.subcategories,
     service_types: data.serviceTypes,

--- a/src/types/__tests__/professional.test.ts
+++ b/src/types/__tests__/professional.test.ts
@@ -1,19 +1,30 @@
-import { PROFILE_TYPE_LABELS, SERVICE_TYPE_LABELS } from '../professional';
+import {
+  PROFILE_TYPE_LABELS,
+  SERVICE_TYPE_LABELS,
+  MONETIZATION_TYPE_LABELS,
+} from '../professional';
 
 describe('PROFILE_TYPE_LABELS', () => {
   it('has a label for every profile type', () => {
-    expect(PROFILE_TYPE_LABELS.shop).toBe('Shop');
-    expect(PROFILE_TYPE_LABELS.service).toBe('Service');
-    expect(PROFILE_TYPE_LABELS.organizer).toBe('Organizer');
-    expect(PROFILE_TYPE_LABELS.classes_circles).toBe('Classes & Circles');
+    expect(PROFILE_TYPE_LABELS.community_organizer).toBe('Community organizer');
+    expect(PROFILE_TYPE_LABELS.nonprofit_organization).toBe('Mosque / association');
+    expect(PROFILE_TYPE_LABELS.business_brand).toBe('Business / brand');
+    expect(PROFILE_TYPE_LABELS.freelancer_service).toBe('Freelancer / service provider');
+  });
+});
+
+describe('MONETIZATION_TYPE_LABELS', () => {
+  it('has a label for every monetization type', () => {
+    expect(MONETIZATION_TYPE_LABELS.nonprofit).toBe('Nonprofit / community-based');
+    expect(MONETIZATION_TYPE_LABELS.for_profit).toBe('For-profit / paid');
   });
 });
 
 describe('SERVICE_TYPE_LABELS', () => {
   it('has a label for every service type', () => {
-    expect(SERVICE_TYPE_LABELS.at_home).toBe('At home');
-    expect(SERVICE_TYPE_LABELS.has_studio).toBe('Has a studio');
+    expect(SERVICE_TYPE_LABELS.in_person).toBe('In person');
     expect(SERVICE_TYPE_LABELS.online).toBe('Online');
+    expect(SERVICE_TYPE_LABELS.hybrid).toBe('Hybrid');
     expect(SERVICE_TYPE_LABELS.travels_to_client).toBe('Travels to client');
   });
 });

--- a/src/types/professional.ts
+++ b/src/types/professional.ts
@@ -1,17 +1,32 @@
-export type ProfileType = 'shop' | 'service' | 'organizer' | 'classes_circles';
+export type ProfileType =
+  | 'community_organizer'
+  | 'nonprofit_organization'
+  | 'business_brand'
+  | 'freelancer_service';
+
+export type MonetizationType = 'nonprofit' | 'for_profit';
+
 export type ProfileStatus =
   | 'draft'
   | 'pending_review'
   | 'approved'
   | 'changes_requested'
-  | 'rejected';
+  | 'rejected'
+  | 'needs_follow_up';
+
+export type MembershipStatus = 'member' | 'verified_applicant' | 'verified_approved';
+
+export type ReviewStatus = 'pending' | 'approved' | 'rejected' | 'needs_follow_up';
+
 export type PriceRange = '$' | '$$' | '$$$';
-export type ServiceTypeValue = 'at_home' | 'has_studio' | 'online' | 'travels_to_client';
+
+export type ServiceTypeValue = 'in_person' | 'online' | 'hybrid' | 'travels_to_client';
 
 export interface Professional {
   id: string;
   businessName: string;
   profileType: ProfileType;
+  monetizationType: MonetizationType;
   category: string;
   subcategories: string[];
   serviceTypes: ServiceTypeValue[];
@@ -33,15 +48,20 @@ export interface Professional {
 // ── Display helpers ───────────────────────────────────────────────────────────
 
 export const PROFILE_TYPE_LABELS: Record<ProfileType, string> = {
-  shop: 'Shop',
-  service: 'Service',
-  organizer: 'Organizer',
-  classes_circles: 'Classes & Circles',
+  community_organizer: 'Community organizer',
+  nonprofit_organization: 'Mosque / association',
+  business_brand: 'Business / brand',
+  freelancer_service: 'Freelancer / service provider',
+};
+
+export const MONETIZATION_TYPE_LABELS: Record<MonetizationType, string> = {
+  nonprofit: 'Nonprofit / community-based',
+  for_profit: 'For-profit / paid',
 };
 
 export const SERVICE_TYPE_LABELS: Record<ServiceTypeValue, string> = {
-  at_home: 'At home',
-  has_studio: 'Has a studio',
+  in_person: 'In person',
   online: 'Online',
+  hybrid: 'Hybrid',
   travels_to_client: 'Travels to client',
 };

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -11,7 +11,8 @@ export type Database = {
           id: string;
           user_id: string;
           business_name: string;
-          profile_type: 'shop' | 'service' | 'organizer' | 'classes_circles';
+          profile_type: string;
+          monetization_type: 'nonprofit' | 'for_profit' | null;
           category: string;
           subcategories: string[];
           service_types: string[];
@@ -26,7 +27,13 @@ export type Database = {
           price_range: '$' | '$$' | '$$$' | null;
           starting_price: string | null;
           logo_uri: string | null;
-          status: 'draft' | 'pending_review' | 'approved' | 'changes_requested' | 'rejected';
+          status:
+            | 'draft'
+            | 'pending_review'
+            | 'approved'
+            | 'changes_requested'
+            | 'rejected'
+            | 'needs_follow_up';
           created_at: string;
           updated_at: string;
         };
@@ -34,7 +41,8 @@ export type Database = {
           id?: string;
           user_id: string;
           business_name: string;
-          profile_type: 'shop' | 'service' | 'organizer' | 'classes_circles';
+          profile_type: string;
+          monetization_type?: 'nonprofit' | 'for_profit' | null;
           category: string;
           subcategories?: string[];
           service_types?: string[];
@@ -49,11 +57,18 @@ export type Database = {
           price_range?: '$' | '$$' | '$$$' | null;
           starting_price?: string | null;
           logo_uri?: string | null;
-          status?: 'draft' | 'pending_review' | 'approved' | 'changes_requested' | 'rejected';
+          status?:
+            | 'draft'
+            | 'pending_review'
+            | 'approved'
+            | 'changes_requested'
+            | 'rejected'
+            | 'needs_follow_up';
         };
         Update: {
           business_name?: string;
-          profile_type?: 'shop' | 'service' | 'organizer' | 'classes_circles';
+          profile_type?: string;
+          monetization_type?: 'nonprofit' | 'for_profit' | null;
           category?: string;
           subcategories?: string[];
           service_types?: string[];
@@ -68,7 +83,13 @@ export type Database = {
           price_range?: '$' | '$$' | '$$$' | null;
           starting_price?: string | null;
           logo_uri?: string | null;
-          status?: 'draft' | 'pending_review' | 'approved' | 'changes_requested' | 'rejected';
+          status?:
+            | 'draft'
+            | 'pending_review'
+            | 'approved'
+            | 'changes_requested'
+            | 'rejected'
+            | 'needs_follow_up';
           updated_at?: string;
         };
         Relationships: [];
@@ -196,10 +217,14 @@ export type Database = {
       };
     };
     Enums: {
-      profile_type: 'shop' | 'service' | 'organizer' | 'classes_circles';
-      profile_status: 'draft' | 'pending_review' | 'approved' | 'changes_requested' | 'rejected';
+      profile_status:
+        | 'draft'
+        | 'pending_review'
+        | 'approved'
+        | 'changes_requested'
+        | 'rejected'
+        | 'needs_follow_up';
       price_range: '$' | '$$' | '$$$';
-      service_type_value: 'at_home' | 'has_studio' | 'online' | 'travels_to_client';
       announcement_type:
         | 'activity_event'
         | 'bazaar'

--- a/supabase/migrations/20260401000000_add_monetization_type.sql
+++ b/supabase/migrations/20260401000000_add_monetization_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE professionals
+ADD COLUMN IF NOT EXISTS monetization_type text
+  CHECK (monetization_type IN ('nonprofit', 'for_profit'));

--- a/supabase/migrations/20260401000001_update_profile_type_enum.sql
+++ b/supabase/migrations/20260401000001_update_profile_type_enum.sql
@@ -1,0 +1,9 @@
+-- Convert profile_type from the old enum to text so new values are accepted.
+-- Validation is enforced at the application layer (Zod schema).
+ALTER TABLE professionals
+  ALTER COLUMN profile_type TYPE text USING profile_type::text;
+
+DROP TYPE IF EXISTS public.profile_type;
+
+-- Also add needs_follow_up to profile_status enum while we're here.
+ALTER TYPE public.profile_status ADD VALUE IF NOT EXISTS 'needs_follow_up';

--- a/supabase/migrations/20260401000002_update_service_type_enum.sql
+++ b/supabase/migrations/20260401000002_update_service_type_enum.sql
@@ -1,0 +1,6 @@
+-- Convert service_types from the old enum array to text[] so new values are accepted.
+-- Validation is enforced at the application layer (Zod schema).
+ALTER TABLE professionals
+  ALTER COLUMN service_types TYPE text[] USING service_types::text[];
+
+DROP TYPE IF EXISTS public.service_type_value;


### PR DESCRIPTION
- Replace role-based signup with a secondary "Apply for a verified profile" link
- Introduce 8-step verified profile wizard with new identity types: community_organizer, nonprofit_organization, business_brand, freelancer_service
- Add monetization step (nonprofit / for_profit) with conditional pricing/booking fields
- Re-theme wizard from dark burgundy to warm cream (#faf6f0) matching auth pages
- Add MonetizationTypeSelector component; update BusinessTypeSelector, StepIndicator, ProfilePreviewCard, ServiceTypeSelector, LocationStep, and all other wizard sub-components
- Skip subcategory and service-type steps for non-freelancer_service profile types
- Add DB migrations: monetization_type column, profile_type/service_type enum → text
- Update Supabase typings (supabase.ts) to reflect schema changes
- Update all affected tests; add MonetizationTypeSelector test suite
- All 395 tests pass; coverage ≥80%; 0 lint errors; typecheck clean